### PR TITLE
Fix everforest plugin to match the one specified by the theme

### DIFF
--- a/pkgbuilds/omarchy-nvim/lua/plugins/all-themes.lua
+++ b/pkgbuilds/omarchy-nvim/lua/plugins/all-themes.lua
@@ -13,7 +13,7 @@ return {
     priority = 1000,
   },
   {
-    "sainnhe/everforest",
+    "neanias/everforest-nvim",
     lazy = true,
     priority = 1000,
   },


### PR DESCRIPTION
Fix `pkgbuilds/omarchy-nvim/lua/plugins/all-themes.lua` to refer to the same nvim plugin that the [Everforest](https://github.com/basecamp/omarchy/blob/master/themes/everforest/neovim.lua) theme actually uses, `neanias/everforest-nvim` instead of `sainnhe/everforest`.

See https://github.com/basecamp/omarchy/blob/master/themes/everforest/neovim.lua.