### PR TITLE
Rebuild terminaltexteffects for Python 3.14

### DIFF
--- a/pkgbuilds/edge/python-terminaltexteffects/PKGBUILD
+++ b/pkgbuilds/edge/python-terminaltexteffects/PKGBUILD
@@ -5,7 +5,7 @@
 pkgname=python-terminaltexteffects
 _pkgname=terminaltexteffects
 pkgver=0.14.2
-pkgrel=2
+pkgrel=3
 pkgdesc='Visual effects engine applied to text in the terminal. '
 url="https://github.com/ChrisBuilds/terminaltexteffects"
 arch=('any')


### PR DESCRIPTION
## Summary
- Bump `pkgrel` to trigger a rebuild for Python 3.14 compatibility
- No upstream version changes