### PR TITLE
Fix invalid placeholder in chromium.desktop

### DIFF
--- a/pkgbuilds/shared/omarchy-chromium-bin/PKGBUILD
+++ b/pkgbuilds/shared/omarchy-chromium-bin/PKGBUILD
@@ -27,4 +27,10 @@ package() {
     
     # Copy everything to the target directory
     cp -r usr "$pkgdir/"
+
+    # Fix invalid placeholder accidentally shipped in chromium.desktop
+    local _desk="$pkgdir/usr/share/applications/chromium.desktop"
+    if [[ -f "$_desk" ]]; then
+       sed -i '/^@@EXTRA_DESKTOP_ENTRIES@@$/d' "$_desk"
+    fi
 }


### PR DESCRIPTION
The omarchy-chromium binary tarball currently ships chromium.desktop with an unresolved placeholder line (@@EXTRA_DESKTOP_ENTRIES@@), which makes the desktop entry invalid and can trigger parsing errors in consumers like xdg-desktop-portal-gtk. This strips the placeholder during packaging so the installed desktop file is always valid.