### PR TITLE
Add qmk-hid package for Framework 16 RGB keyboard support

### DIFF
--- a/build/packages/edge.packages
+++ b/build/packages/edge.packages
@@ -2,6 +2,7 @@
 
 # Core
 asusctl
+qmk-hid
 elephant install
 elephant-archlinuxpkgs
 elephant-bluetooth

--- a/pkgbuilds/edge/qmk-hid/.SRCINFO
+++ b/pkgbuilds/edge/qmk-hid/.SRCINFO
@@ -1,0 +1,16 @@
+pkgbase = qmk-hid
+	pkgdesc = Commandline tool for interacting with QMK devices over HID
+	pkgver = 0.1.11
+	pkgrel = 3
+	url = https://github.com/FrameworkComputer/qmk_hid
+	arch = x86_64
+	license = BSD
+	makedepends = cargo
+	depends = gcc-libs
+	depends = systemd-libs
+	depends = libcap
+	options = !lto
+	source = qmk-hid-0.1.11.tar.gz::https://github.com/FrameworkComputer/qmk_hid/archive/v0.1.11.tar.gz
+	b2sums = e898d27cfe8350f4a8cd2938a3d066935093daf1292f41fc10b8f1937059f2b59e4ac34a987f26c8258a5d3b15a900059024fe3a18ed793f7e3b524939ab4c71
+
+pkgname = qmk-hid

--- a/pkgbuilds/edge/qmk-hid/PKGBUILD
+++ b/pkgbuilds/edge/qmk-hid/PKGBUILD
@@ -1,0 +1,43 @@
+# Maintainer: Mike Yuan <me@yhndnzj.com>
+
+pkgname=qmk-hid
+_srcname=qmk_hid
+pkgver=0.1.11
+pkgrel=3
+pkgdesc="Commandline tool for interacting with QMK devices over HID"
+arch=('x86_64')
+url="https://github.com/FrameworkComputer/qmk_hid"
+license=('BSD')
+depends=('gcc-libs' 'systemd-libs' 'libcap')
+makedepends=('cargo')
+source=("$pkgname-$pkgver.tar.gz::$url/archive/v$pkgver.tar.gz")
+b2sums=('e898d27cfe8350f4a8cd2938a3d066935093daf1292f41fc10b8f1937059f2b59e4ac34a987f26c8258a5d3b15a900059024fe3a18ed793f7e3b524939ab4c71')
+options=('!lto')
+
+prepare() {
+    cd "$_srcname-$pkgver"
+
+    export RUSTUP_TOOLCHAIN=stable
+    cargo fetch --locked --target "$CARCH-unknown-linux-gnu"
+}
+
+build() {
+    cd "$_srcname-$pkgver"
+
+    export RUSTUP_TOOLCHAIN=stable
+    export CARGO_TARGET_DIR=target
+    cargo build --frozen --release --all-features
+}
+
+#check() {
+#    cd "$_srcname-$pkgver"
+#
+#    export RUSTUP_TOOLCHAIN=stable
+#    cargo test --frozen --all-features
+#}
+
+package() {
+    cd "$_srcname-$pkgver"
+    install -Dm755 "target/release/$_srcname" "$pkgdir/usr/bin/$_srcname"
+    install -Dm644 LICENSE.md "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+}


### PR DESCRIPTION
## Context

This package is needed to support Framework Laptop 16 RGB keyboard theme syncing in basecamp/omarchy#4524. That PR adds the ability to sync Omarchy's theme accent color to the Framework 16's RGB keyboard backlight.

The package is placed in the edge tier, consistent with the similar hardware-specific asusctl package for ASUS ROG keyboard control.

## What This Package Does

qmk-hid (https://aur.archlinux.org/packages/qmk-hid) provides qmk_hid, a CLI tool developed by Framework Computer for bidirectional communication with QMK-firmware keyboards over raw HID (VIA API). 

Main repo is here: https://github.com/FrameworkComputer/qmk_hid

## How I Tested 

Validated the package through these steps:
1. Built the package locally using ./bin/build --package qmk-hid
   - Used the repo's Docker-based build system
   - Successfully compiled the Rust/Cargo project
   - Produced valid .pkg.tar.zst files
2. Verified package metadata with pacman -Qp
   - Confirmed version: 0.1.11-3
3. Tested binary execution
   - Ran /tmp/qmk-test/usr/bin/qmk_hid --version
   - Output: qmk_hid 0.1.11 
   
   
Quick note that the AUR package is currently on `0.1.11` but the github for qmk_hid latest release is `0.1.13`.  
