### PR TITLE
Fix nvim transparency to preserve foreground colors

### DIFF
--- a/pkgbuilds/edge/omarchy-nvim/plugin/after/transparency.lua
+++ b/pkgbuilds/edge/omarchy-nvim/plugin/after/transparency.lua
@@ -1,47 +1,59 @@
--- transparent background
-vim.api.nvim_set_hl(0, "Normal", { bg = "none" })
-vim.api.nvim_set_hl(0, "NormalFloat", { bg = "none" })
-vim.api.nvim_set_hl(0, "FloatBorder", { bg = "none" })
-vim.api.nvim_set_hl(0, "Pmenu", { bg = "none" })
-vim.api.nvim_set_hl(0, "Terminal", { bg = "none" })
-vim.api.nvim_set_hl(0, "EndOfBuffer", { bg = "none" })
-vim.api.nvim_set_hl(0, "FoldColumn", { bg = "none" })
-vim.api.nvim_set_hl(0, "Folded", { bg = "none" })
-vim.api.nvim_set_hl(0, "SignColumn", { bg = "none" })
-vim.api.nvim_set_hl(0, "NormalNC", { bg = "none" })
-vim.api.nvim_set_hl(0, "LineNr", { bg = "none" })
-vim.api.nvim_set_hl(0, "CursorLineNr", { bg = "none" })
-vim.api.nvim_set_hl(0, "WhichKeyFloat", { bg = "none" })
-vim.api.nvim_set_hl(0, "TelescopeBorder", { bg = "none" })
-vim.api.nvim_set_hl(0, "TelescopeNormal", { bg = "none" })
-vim.api.nvim_set_hl(0, "TelescopePromptBorder", { bg = "none" })
-vim.api.nvim_set_hl(0, "TelescopePromptTitle", { bg = "none" })
+-- Make highlight groups transparent while preserving their other attributes
+local function make_transparent(name)
+	local ok, hl = pcall(vim.api.nvim_get_hl, 0, { name = name, link = false })
+	if ok then
+		hl.bg = nil
+		vim.api.nvim_set_hl(0, name, hl)
+	end
+end
 
--- transparent background for neotree
-vim.api.nvim_set_hl(0, "NeoTreeNormal", { bg = "none" })
-vim.api.nvim_set_hl(0, "NeoTreeNormalNC", { bg = "none" })
-vim.api.nvim_set_hl(0, "NeoTreeVertSplit", { bg = "none" })
-vim.api.nvim_set_hl(0, "NeoTreeWinSeparator", { bg = "none" })
-vim.api.nvim_set_hl(0, "NeoTreeEndOfBuffer", { bg = "none" })
+local groups = {
+	-- transparent background
+	"Normal",
+	"NormalFloat",
+	"FloatBorder",
+	"Pmenu",
+	"Terminal",
+	"EndOfBuffer",
+	"FoldColumn",
+	"Folded",
+	"SignColumn",
+	"LineNr",
+	"CursorLineNr",
+	"NormalNC",
+	"WhichKeyFloat",
+	"TelescopeBorder",
+	"TelescopeNormal",
+	"TelescopePromptBorder",
+	"TelescopePromptTitle",
+	-- neotree
+	"NeoTreeNormal",
+	"NeoTreeNormalNC",
+	"NeoTreeVertSplit",
+	"NeoTreeWinSeparator",
+	"NeoTreeEndOfBuffer",
+	-- nvim-tree
+	"NvimTreeNormal",
+	"NvimTreeVertSplit",
+	"NvimTreeEndOfBuffer",
+	-- notify
+	"NotifyINFOBody",
+	"NotifyERRORBody",
+	"NotifyWARNBody",
+	"NotifyTRACEBody",
+	"NotifyDEBUGBody",
+	"NotifyINFOTitle",
+	"NotifyERRORTitle",
+	"NotifyWARNTitle",
+	"NotifyTRACETitle",
+	"NotifyDEBUGTitle",
+	"NotifyINFOBorder",
+	"NotifyERRORBorder",
+	"NotifyWARNBorder",
+	"NotifyTRACEBorder",
+	"NotifyDEBUGBorder",
+}
 
--- transparent background for nvim-tree
-vim.api.nvim_set_hl(0, "NvimTreeNormal", { bg = "none" })
-vim.api.nvim_set_hl(0, "NvimTreeVertSplit", { bg = "none" })
-vim.api.nvim_set_hl(0, "NvimTreeEndOfBuffer", { bg = "none" })
-
--- transparent notify background
-vim.api.nvim_set_hl(0, "NotifyINFOBody", { bg = "none" })
-vim.api.nvim_set_hl(0, "NotifyERRORBody", { bg = "none" })
-vim.api.nvim_set_hl(0, "NotifyWARNBody", { bg = "none" })
-vim.api.nvim_set_hl(0, "NotifyTRACEBody", { bg = "none" })
-vim.api.nvim_set_hl(0, "NotifyDEBUGBody", { bg = "none" })
-vim.api.nvim_set_hl(0, "NotifyINFOTitle", { bg = "none" })
-vim.api.nvim_set_hl(0, "NotifyERRORTitle", { bg = "none" })
-vim.api.nvim_set_hl(0, "NotifyWARNTitle", { bg = "none" })
-vim.api.nvim_set_hl(0, "NotifyTRACETitle", { bg = "none" })
-vim.api.nvim_set_hl(0, "NotifyDEBUGTitle", { bg = "none" })
-vim.api.nvim_set_hl(0, "NotifyINFOBorder", { bg = "none" })
-vim.api.nvim_set_hl(0, "NotifyERRORBorder", { bg = "none" })
-vim.api.nvim_set_hl(0, "NotifyWARNBorder", { bg = "none" })
-vim.api.nvim_set_hl(0, "NotifyTRACEBorder", { bg = "none" })
-vim.api.nvim_set_hl(0, "NotifyDEBUGBorder", { bg = "none" })
+for _, name in ipairs(groups) do
+	make_transparent(name)
+end


### PR DESCRIPTION
## Summary

- `nvim_set_hl(0, name, { bg = "none" })` replaces the entire highlight definition, wiping foreground and other attributes — not just the background
- This breaks snacks.nvim's GitHub integration (`<leader>gp` for PRs, `<leader>gi` for issues) which reads fg from `Normal`/`NormalFloat` at module load time, gets `nil`, and crashes
- The fix uses `nvim_get_hl` to fetch existing attributes first, removes only `bg`, then sets the highlight back

Companion PR for existing installs (migration): https://github.com/basecamp/omarchy/pull/4844

## Test plan

- [ ] Open nvim in a git repo and press `<leader>gp` — should open the GitHub PR picker without errors
- [ ] Verify transparent backgrounds still work correctly
- [ ] Verify foreground colors are preserved (text should look the same as before)

🤖 Generated with [Claude Code](https://claude.com/claude-code)