### PR TITLE
Skip transparency overrides in Neovide

### DIFF
--- a/pkgbuilds/edge/omarchy-nvim/plugin/after/transparency.lua
+++ b/pkgbuilds/edge/omarchy-nvim/plugin/after/transparency.lua
@@ -1,3 +1,7 @@
+if vim.g.neovide then
+	return
+end
+
 -- Make highlight groups transparent while preserving their other attributes
 local function make_transparent(name)
 	local ok, hl = pcall(vim.api.nvim_get_hl, 0, { name = name, link = false })

--- a/pkgbuilds/edge/omarchy-nvim/plugin/after/transparency.lua
+++ b/pkgbuilds/edge/omarchy-nvim/plugin/after/transparency.lua
@@ -1,3 +1,5 @@
+-- Neovide handles background rendering differently; skip transparency overrides
+-- to avoid forcing a black background
 if vim.g.neovide then
 	return
 end


### PR DESCRIPTION
Skip transparency overrides in Neovide

Prevent transparency highlight overrides from running in Neovide.

This avoids the black background issue caused by clearing bg on groups like
Normal and NormalNC, while keeping existing terminal Neovim behavior unchanged.

Closes basecamp/omarchy#5107

@dhh I’ve moved the PR and adjusted it accordingly. Would appreciate a review when you have a moment.