### PR TITLE
Intel lpmd power profile integration

### DIFF
--- a/pkgbuilds/edge/intel-lpmd/.SRCINFO
+++ b/pkgbuilds/edge/intel-lpmd/.SRCINFO
@@ -19,6 +19,6 @@ pkgbase = intel-lpmd
 	source = git+https://github.com/intel/intel-lpmd.git#tag=v0.1.0
 	source = intel_lpmd_config_F6_M204.xml
 	sha256sums = 23f4c8588cc057c327c6b031c377b03193d62554f3b5a68284582f4e5a35c462
-	sha256sums = 1803f9a6eb3ceb069592c5c9cd5a650aedf22a3c1a2c5dce6da80338b7cb4876
+	sha256sums = fca6e1f95985c8e2d92e104f6b129943fc1de9f98a1792888e1fa9c5f50a6867
 
 pkgname = intel-lpmd

--- a/pkgbuilds/edge/intel-lpmd/.SRCINFO
+++ b/pkgbuilds/edge/intel-lpmd/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = intel-lpmd
 	pkgdesc = Intel Low Power Mode Daemon
 	pkgver = 0.1.0
-	pkgrel = 1
+	pkgrel = 2
 	url = https://github.com/intel/intel-lpmd
 	arch = x86_64
 	license = GPL-2.0-or-later
@@ -17,6 +17,8 @@ pkgbase = intel-lpmd
 	depends = polkit
 	depends = upower
 	source = git+https://github.com/intel/intel-lpmd.git#tag=v0.1.0
+	source = intel_lpmd_config_F6_M204.xml
 	sha256sums = 23f4c8588cc057c327c6b031c377b03193d62554f3b5a68284582f4e5a35c462
+	sha256sums = 1803f9a6eb3ceb069592c5c9cd5a650aedf22a3c1a2c5dce6da80338b7cb4876
 
 pkgname = intel-lpmd

--- a/pkgbuilds/edge/intel-lpmd/PKGBUILD
+++ b/pkgbuilds/edge/intel-lpmd/PKGBUILD
@@ -1,15 +1,17 @@
 # Maintainer: Norbert Preining <norbert@preining.info>
 pkgname=intel-lpmd
 pkgver=0.1.0
-pkgrel=1
+pkgrel=2
 pkgdesc="Intel Low Power Mode Daemon"
 arch=('x86_64')
 url="https://github.com/intel/$pkgname"
 license=('GPL-2.0-or-later')
 makedepends=('git' 'automake' 'autoconf-archive' 'gtk-doc' 'glib2-devel' 'systemd')
 depends=('libxml2-legacy' 'libnl' 'systemd-libs' 'polkit' 'upower')
-source=(git+${url}.git#tag=v${pkgver})
-sha256sums=('23f4c8588cc057c327c6b031c377b03193d62554f3b5a68284582f4e5a35c462')
+source=(git+${url}.git#tag=v${pkgver}
+        intel_lpmd_config_F6_M204.xml)
+sha256sums=('23f4c8588cc057c327c6b031c377b03193d62554f3b5a68284582f4e5a35c462'
+            '1803f9a6eb3ceb069592c5c9cd5a650aedf22a3c1a2c5dce6da80338b7cb4876')
 
 prepare() {
 	cd "$pkgname"
@@ -24,6 +26,7 @@ build() {
 package() {
 	cd "$pkgname"
 	DESTDIR="$pkgdir" make install
+	install -Dm 644 "$srcdir/intel_lpmd_config_F6_M204.xml" "$pkgdir/etc/intel_lpmd/intel_lpmd_config_F6_M204.xml"
 	install -Dm 644 -t "${pkgdir}/usr/share/doc/${pkgname}" "$srcdir/${pkgname}"/README.md
 	install -Dm 644 -t "${pkgdir}/usr/share/doc/${pkgname}" "$srcdir/${pkgname}"/doc/WLT_proxy.md
 }

--- a/pkgbuilds/edge/intel-lpmd/PKGBUILD
+++ b/pkgbuilds/edge/intel-lpmd/PKGBUILD
@@ -11,7 +11,7 @@ depends=('libxml2-legacy' 'libnl' 'systemd-libs' 'polkit' 'upower')
 source=(git+${url}.git#tag=v${pkgver}
         intel_lpmd_config_F6_M204.xml)
 sha256sums=('23f4c8588cc057c327c6b031c377b03193d62554f3b5a68284582f4e5a35c462'
-            '1803f9a6eb3ceb069592c5c9cd5a650aedf22a3c1a2c5dce6da80338b7cb4876')
+            'fca6e1f95985c8e2d92e104f6b129943fc1de9f98a1792888e1fa9c5f50a6867')
 
 prepare() {
 	cd "$pkgname"

--- a/pkgbuilds/edge/intel-lpmd/intel_lpmd_config_F6_M204.xml
+++ b/pkgbuilds/edge/intel-lpmd/intel_lpmd_config_F6_M204.xml
@@ -1,0 +1,213 @@
+<?xml version="1.0"?>
+
+<!--
+Specifies the configuration data
+for Intel Energy Optimizer (LPMD) daemon
+-->
+
+<Configuration>
+	<!--
+		CPU format example: 1,2,4..6,8-10
+	-->
+	<lp_mode_cpus></lp_mode_cpus>
+
+	<!--
+		EPP to use in Low Power Mode
+		0-255: Valid EPP value to use in Low Power Mode
+		   -1: Don't change EPP in Low Power Mode
+	-->
+	<lp_mode_epp></lp_mode_epp>
+
+	<!--
+		Mode values
+		0: Cgroup v2
+		1: Cgroup v2 isolate
+		2: CPU idle injection
+	-->
+	<Mode>0</Mode>
+
+	<!--
+		Default behavior when Performance power setting is used
+		-1: force off. (Never enter Low Power Mode)
+		 1: force on. (Always stay in Low Power Mode)
+		 0: auto. (opportunistic Low Power Mode enter/exit)
+	-->
+	<PerformanceDef>-1</PerformanceDef>
+
+	<!--
+		Default behavior when Balanced power setting is used
+		-1: force off. (Never enter Low Power Mode)
+		 1: force on. (Always stay in Low Power Mode)
+		 0: auto. (opportunistic Low Power Mode enter/exit)
+	-->
+	<BalancedDef>0</BalancedDef>
+
+	<!--
+		Default behavior when Power saver setting is used
+		-1: force off. (Never enter Low Power Mode)
+		 1: force on. (Always stay in Low Power Mode)
+		 0: auto. (opportunistic Low Power Mode enter/exit)
+	-->
+	<PowersaverDef>0</PowersaverDef>
+
+	<!--
+		Use HFI LPM hints
+		0 : No
+		1 : Yes
+	-->
+	<HfiLpmEnable>0</HfiLpmEnable>
+
+	<!--
+		Use WLT hints
+		0 : No
+		1 : Yes
+	-->
+	<WLTHintEnable>1</WLTHintEnable>
+
+	<!--
+		Use WLT hint Poll enable
+		0 : No
+		1 : Yes
+	-->
+	<WLTHintPollEnable>0</WLTHintPollEnable>
+
+	<!--
+		Use WLT hint Mask
+		0 : Non
+		* : Value to AND with with the hardware hint
+	-->
+	<WLTHintMask>15</WLTHintMask>
+
+	<!--
+		Use HFI SUV hints
+		0 : No
+		1 : Yes
+	-->
+	<HfiSuvEnable>0</HfiSuvEnable>
+
+	<!--
+		System utilization threshold to enter LP mode
+		from 0 - 100
+		clear both util_entry_threshold and util_exit_threshold to disable util monitor
+	<util_entry_threshold>0</util_entry_threshold>
+	-->
+
+	<!--
+		System utilization threshold to exit LP mode
+		from 0 - 100
+		clear both util_entry_threshold and util_exit_threshold to disable util monitor
+	<util_exit_threshold>0</util_exit_threshold>
+	-->
+
+	<!--
+		Entry delay. Minimum delay in non Low Power mode to
+		enter LPM mode.
+	<EntryDelayMS>0</EntryDelayMS>
+	-->
+
+	<!--
+		Exit delay. Minimum delay in Low Power mode to
+		exit LPM mode.
+	<ExitDelayMS>0</ExitDelayMS>
+	-->
+
+	<!--
+		Lowest hysteresis average in-LP-mode time in msec to enter LP mode
+		0: to disable hysteresis support
+	<EntryHystMS>0</EntryHystMS>
+	-->
+
+	<!--
+		Lowest hysteresis average out-of-LP-mode time in msec to exit LP mode
+		0: to disable hysteresis support
+	<ExitHystMS>0</ExitHystMS>
+	-->
+
+	<!--
+		Ignore ITMT setting during LP-mode enter/exit
+		0: disable ITMT upon LP-mode enter and re-enable ITMT upon LP-mode exit
+		1: do not touch ITMT setting during LP-mode enter/exit
+	-->
+	<IgnoreITMT>0</IgnoreITMT>
+
+	<!--
+		Slider default configuration for AC and DC
+	-->
+	<BalancedSliderAC>1</BalancedSliderAC>
+	<BalancedSliderDC>3</BalancedSliderDC>
+	<SliderOffsetAC>0</SliderOffsetAC>
+	<SliderOffsetDC>3</SliderOffsetDC>
+
+	<States>
+		<CPUFamily> 6 </CPUFamily>
+		<CPUModel> 204 </CPUModel>
+		<CPUConfig> 4P8E4L-25W </CPUConfig>
+		<State>
+			<ID> 1 </ID>
+			<Name> UTIL_IDLE </Name>
+			<WLTType> 1 </WLTType>
+			<ActiveCPUs>12-15</ActiveCPUs>
+		</State>
+		<State>
+			<ID> 2 </ID>
+			<Name> UTIL_IDLE_SUSTAIN </Name>
+			<WLTType> 2 </WLTType>
+			<ActiveCPUs>0-15</ActiveCPUs>
+		</State>
+		<State>
+			<ID> 3 </ID>
+			<Name> UTIL_IDLE_BURSTY </Name>
+			<WLTType> 3 </WLTType>
+			<ActiveCPUs>0-15</ActiveCPUs>
+		</State>
+	</States>
+
+	<States>
+		<CPUFamily> 6 </CPUFamily>
+		<CPUModel> 204 </CPUModel>
+		<CPUConfig> 4P4E4L-25W </CPUConfig>
+		<State>
+			<ID> 1 </ID>
+			<Name> UTIL_IDLE </Name>
+			<WLTType> 1 </WLTType>
+			<ActiveCPUs>8-11</ActiveCPUs>
+		</State>
+		<State>
+			<ID> 2 </ID>
+			<Name> UTIL_IDLE_SUSTAIN </Name>
+			<WLTType> 2 </WLTType>
+			<ActiveCPUs>0-11</ActiveCPUs>
+		</State>
+		<State>
+			<ID> 3 </ID>
+			<Name> UTIL_IDLE_BURSTY </Name>
+			<WLTType> 3 </WLTType>
+			<ActiveCPUs>0-11</ActiveCPUs>
+		</State>
+	</States>
+
+	<States>
+		<CPUFamily> 6 </CPUFamily>
+		<CPUModel> 204 </CPUModel>
+		<CPUConfig> 4P0E4L-25W </CPUConfig>
+		<State>
+			<ID> 1 </ID>
+			<Name> UTIL_IDLE </Name>
+			<WLTType> 1 </WLTType>
+			<ActiveCPUs>4-7</ActiveCPUs>
+		</State>
+		<State>
+			<ID> 2 </ID>
+			<Name> UTIL_IDLE_SUSTAIN </Name>
+			<WLTType> 2 </WLTType>
+			<ActiveCPUs>0-7</ActiveCPUs>
+		</State>
+		<State>
+			<ID> 3 </ID>
+			<Name> UTIL_IDLE_BURSTY </Name>
+			<WLTType> 3 </WLTType>
+			<ActiveCPUs>0-7</ActiveCPUs>
+		</State>
+	</States>
+
+</Configuration>

--- a/pkgbuilds/edge/intel-lpmd/intel_lpmd_config_F6_M204.xml
+++ b/pkgbuilds/edge/intel-lpmd/intel_lpmd_config_F6_M204.xml
@@ -48,7 +48,7 @@ for Intel Energy Optimizer (LPMD) daemon
 		 1: force on. (Always stay in Low Power Mode)
 		 0: auto. (opportunistic Low Power Mode enter/exit)
 	-->
-	<PowersaverDef>0</PowersaverDef>
+	<PowersaverDef>1</PowersaverDef>
 
 	<!--
 		Use HFI LPM hints


### PR DESCRIPTION
## Summary
- Ship an Omarchy-tuned Panther Lake `intel-lpmd` config instead of relying on Intel’s disabled-by-default template.
- Make `power-saver` a distinct mode by forcing LPM on, while keeping `balanced` opportunistic and `performance` off.
- Fix the Panther Lake `F6_M204` model config so the shipped CPU mappings match the actual low-power core layout.
## Why
Intel ships `intel-lpmd` configs as conservative templates and leaves LPM effectively disabled by default. That means installing and enabling the daemon alone does not give Omarchy users a meaningful three-mode power policy.
For Omarchy, we want the profiles to behave distinctly:
- `performance`: prioritize responsiveness and keep the full CPU set available
- `balanced`: allow opportunistic low power behavior when the system is lightly loaded
- `power-saver`: maximize battery savings by keeping the system pinned to the low-power core set
This change moves that policy into the package so supported Panther Lake systems get the intended behavior immediately when `intel-lpmd` is installed.
## What Changed
- Added a packaged Panther Lake config at:
  - `/etc/intel_lpmd/intel_lpmd_config_F6_M204.xml`
- Set the default profile behavior to the following to match with the omarchy default boot behavior so they are in sync:
  - `PerformanceDef=-1`
  - `BalancedDef=0`
  - `PowersaverDef=1`
- Kept `Mode=0` for cgroup v2-based enforcement
- Corrected the Panther Lake state tables to match the expected low-power CPU groups:
  - `4P8E4L-25W -> 12-15`
  - `4P4E4L-25W -> 8-11`
  - `4P0E4L-25W -> 4-7`
- Bumped `pkgrel` to `2`
## Expected Behavior
On supported Panther Lake systems:
- `performance` should leave `system.slice` on the full cpuset:
  - `0-15`
- `balanced` should opportunistically enter low-power mode when lightly loaded, but open back up under load
- `power-saver` should keep `system.slice` pinned to the low-power cpuset:
  - `12-15`