### PR TITLE
Add libfprint-git package with FocalTech FT9349 PID 0xa97a patch

### DIFF
--- a/pkgbuilds/edge/libfprint-git/PKGBUILD
+++ b/pkgbuilds/edge/libfprint-git/PKGBUILD
@@ -1,0 +1,87 @@
+# Maintainer: Mikko Nyman <mikko@nyman.xyz>
+# Based on the Arch libfprint package by Jan Alexander Steffens (heftig).
+#
+# Tracks libfprint master to expose the focaltech_moc driver for ASUS
+# laptops with FocalTech MOC (Match-on-Chip) fingerprint sensors. The
+# driver is in master under LGPL but mainline libfprint releases (1.94.x)
+# do not yet ship it. Carries one extra patch adding USB ID 2808:a97a
+# (FocalTech FT9349 ESS, ASUS ExpertBook Ultra B9406CAA) to the driver's
+# id_table[]; the upstream MR is in flight.
+#
+# Once the patch lands and Arch's libfprint catches up, this package can
+# be removed from the OPR repo and Omarchy can install stock libfprint.
+
+pkgname=libfprint-git
+pkgver=1.94.10.r12.gd79f157
+pkgrel=1
+pkgdesc="Library for fingerprint readers (libfprint master with FocalTech FT9349 PID 0xa97a patch)"
+url="https://fprint.freedesktop.org/"
+arch=(x86_64)
+license=(LGPL-2.1-or-later)
+depends=(
+  gcc-libs
+  glib2
+  glibc
+  libgudev
+  libgusb
+  openssl
+  pixman
+)
+makedepends=(
+  git
+  glib2-devel
+  gobject-introspection
+  gtk-doc
+  meson
+  python-cairo
+  python-gobject
+  systemd
+)
+checkdepends=(
+  cairo
+  umockdev
+)
+provides=(libfprint libfprint-2.so)
+conflicts=(libfprint)
+groups=(fprint)
+source=(
+  "git+https://gitlab.freedesktop.org/libfprint/libfprint.git"
+  "focaltech_moc-add-pid-0xA97A.patch"
+)
+b2sums=(
+  'SKIP'
+  'SKIP'
+)
+
+pkgver() {
+  cd libfprint
+  ( set -o pipefail
+    git describe --long --tags --abbrev=7 2>/dev/null \
+      | sed 's/^v//;s/\([^-]*-g\)/r\1/;s/-/./g' \
+      || printf "r%s.%s" "$(git rev-list --count HEAD)" "$(git rev-parse --short=7 HEAD)"
+  )
+}
+
+prepare() {
+  cd libfprint
+  patch -p1 < "$srcdir/focaltech_moc-add-pid-0xA97A.patch"
+}
+
+build() {
+  local meson_options=(
+    -D drivers=all
+    -D installed-tests=false
+  )
+  arch-meson libfprint build "${meson_options[@]}"
+  meson compile -C build
+}
+
+check() {
+  meson test -C build --print-errorlogs
+}
+
+package() {
+  meson install -C build --destdir "$pkgdir"
+}
+
+# vim:set sw=2 sts=-1 et:

--- a/pkgbuilds/edge/libfprint-git/focaltech_moc-add-pid-0xA97A.patch
+++ b/pkgbuilds/edge/libfprint-git/focaltech_moc-add-pid-0xA97A.patch
@@ -1,0 +1,24 @@
+From acfa370b92604c4e6d55f79ed283ed2b05da32de Mon Sep 17 00:00:00 2001
+From: Mikko Nyman <mikko@nyman.xyz>
+Date: Sat, 25 Apr 2026 17:43:18 +0300
+Subject: [PATCH] focaltech_moc: add new pid:0xA97A
+
+---
+ libfprint/drivers/focaltech_moc/focaltech_moc.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/libfprint/drivers/focaltech_moc/focaltech_moc.c b/libfprint/drivers/focaltech_moc/focaltech_moc.c
+index 8bd93e4..23dac16 100644
+--- a/libfprint/drivers/focaltech_moc/focaltech_moc.c
++++ b/libfprint/drivers/focaltech_moc/focaltech_moc.c
+@@ -37,6 +37,7 @@ static const FpIdEntry id_table[] = {
+   { .vid = 0x2808,  .pid = 0x1579,  },
+   { .vid = 0x2808,  .pid = 0x077A,  },
+   { .vid = 0x2808,  .pid = 0x079A,  },
++  { .vid = 0x2808,  .pid = 0xA97A,  },
+   { .vid = 0,  .pid = 0,  .driver_data = 0 },   /* terminating entry */
+ };
+ 
+-- 
+2.54.0
+


### PR DESCRIPTION
Mainline libfprint (1.94.x) does not yet ship the open-source focaltech_moc driver. The driver lives in libfprint master under LGPL but the official Arch package builds from the v1.94.10 tag, so the driver is unavailable on Arch / Omarchy.

The driver is otherwise complete; it just needs USB ID 2808:a97a added to id_table[] for the FocalTech FT9349 ESS sensor shipped in the ASUS ExpertBook Ultra B9406CAA. The upstream MR with that one-line addition is in flight at gitlab.freedesktop.org/libfprint/libfprint.

This package builds libfprint master, applies the one-line patch, and installs as libfprint-git. provides=libfprint conflicts=libfprint so it cleanly replaces the stock package.

Tested locally: makepkg -s succeeds; built lib contains the focaltech_moc driver; id_table[] in the build tree includes 0xA97A. The same patched build has been tested with enrollment, verification, suspend/resume all working.

Once upstream lands and Arch's libfprint catches up to a release that includes both, this package can be removed from OPR.

AI disclaimer: investigation and patch produced with help from Claude Code (Opus 4.7).