### PR TITLE
Fix: gpu-screen-recorder is breaking hibernation on some NVidia systems

### DIFF
--- a/pkgbuilds/edge/gpu-screen-recorder/.SRCINFO
+++ b/pkgbuilds/edge/gpu-screen-recorder/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = gpu-screen-recorder
 	pkgdesc = A shadowplay-like screen recorder for Linux. The fastest screen recorder for Linux
 	pkgver = 5.12.3
-	pkgrel = 1
+	pkgrel = 2
 	url = https://git.dec05eba.com/gpu-screen-recorder
 	install = gpu-screen-recorder.install
 	arch = x86_64

--- a/pkgbuilds/edge/gpu-screen-recorder/PKGBUILD
+++ b/pkgbuilds/edge/gpu-screen-recorder/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=gpu-screen-recorder
 pkgver=5.12.3
-pkgrel=1
+pkgrel=2
 pkgdesc='A shadowplay-like screen recorder for Linux. The fastest screen recorder for Linux'
 arch=('x86_64')
 url="https://git.dec05eba.com/gpu-screen-recorder"
@@ -43,7 +43,7 @@ install="${pkgname}.install" # setcap cap_sys_admin (gsr-kms-server)
 
 build() {
   cd "$srcdir"
-  arch-meson build -Dsystemd=true --buildtype=release -Dstrip=true
+  arch-meson build -Dsystemd=true -Dnvidia_suspend_fix=false --buildtype=release -Dstrip=true
   meson compile -C build
 }
 


### PR DESCRIPTION
I found out the root cause preventing my system from hibernating and documented it on https://github.com/basecamp/omarchy/discussions/5500.

This commit hopefully avoid `gsr-nvidia.conf` from being installed with gpu-screen-recorder. ([ref commit](https://git.dec05eba.com/gpu-screen-recorder/commit/?id=5e3a3714dd020d1a1b45f8cbc6239ba15da580db))