### PR TITLE
Migrating to a fork for `asdcontrol`

### DIFF
--- a/pkgbuilds/edge/asdcontrol/.SRCINFO
+++ b/pkgbuilds/edge/asdcontrol/.SRCINFO
@@ -1,8 +1,8 @@
 pkgbase = asdcontrol
 	pkgdesc = Control brightness on Apple Displays connected via USB-C
-	pkgver = 0.23.0ee8bd5
+	pkgver = 0.6.0
 	pkgrel = 1
-	url = https://github.com/nikosdion/asdcontrol
+	url = https://github.com/omakasui/asdcontrol
 	install = asdcontrol.install
 	arch = x86_64
 	license = GPL2
@@ -10,7 +10,7 @@ pkgbase = asdcontrol
 	makedepends = gcc
 	depends = glibc
 	depends = gcc-libs
-	source = asdcontrol-0.23.0ee8bd5.tar.gz::https://github.com/nikosdion/asdcontrol/archive/0ee8bd5.tar.gz
-	sha256sums = 1381ba2e048ec73aa0f8c32e47370460efd31b31f7558a7b922a3c4ebef00ebc
+	source = asdcontrol-0.6.0.tar.gz::https://github.com/omakasui/asdcontrol/archive/refs/tags/v0.6.0.tar.gz
+	sha256sums = 3112a6d5fc51a204c96ef9d27187577c6efc80b952e37a77969efbd0124e81d3
 
 pkgname = asdcontrol

--- a/pkgbuilds/edge/asdcontrol/.SRCINFO
+++ b/pkgbuilds/edge/asdcontrol/.SRCINFO
@@ -1,5 +1,6 @@
 pkgbase = asdcontrol
 	pkgdesc = Control brightness on Apple Displays connected via USB-C
+	epoch = 1
 	pkgver = 0.6.0
 	pkgrel = 1
 	url = https://github.com/omakasui/asdcontrol

--- a/pkgbuilds/edge/asdcontrol/PKGBUILD
+++ b/pkgbuilds/edge/asdcontrol/PKGBUILD
@@ -1,25 +1,25 @@
 # Maintainer: Ryan Hughes <ryan@omarchy.org>
 pkgname=asdcontrol
-pkgver=0.23.0ee8bd5
+pkgver=0.6.0
 pkgrel=1
 pkgdesc="Control brightness on Apple Displays connected via USB-C"
 arch=('x86_64')
-url="https://github.com/nikosdion/asdcontrol"
+url="https://github.com/omakasui/asdcontrol"
 license=('GPL2')
 options=('!debug')
 depends=('glibc' 'gcc-libs')
 makedepends=('make' 'gcc')
-source=("$pkgname-$pkgver.tar.gz::https://github.com/nikosdion/asdcontrol/archive/0ee8bd5.tar.gz")
-sha256sums=('1381ba2e048ec73aa0f8c32e47370460efd31b31f7558a7b922a3c4ebef00ebc')
+source=("$pkgname-$pkgver.tar.gz::https://github.com/omakasui/asdcontrol/archive/refs/tags/v$pkgver.tar.gz")
+sha256sums=('3112a6d5fc51a204c96ef9d27187577c6efc80b952e37a77969efbd0124e81d3')
 install=asdcontrol.install
 
 build() {
-  cd "$srcdir/asdcontrol-0ee8bd576d4e93513027d713e688988cb0d827ef"
+  cd "$srcdir/asdcontrol-$pkgver"
   make
 }
 
 package() {
-  cd "$srcdir/asdcontrol-0ee8bd576d4e93513027d713e688988cb0d827ef"
+  cd "$srcdir/asdcontrol-$pkgver"
 
   # Install the binary
   install -Dm755 asdcontrol "$pkgdir/usr/bin/asdcontrol"

--- a/pkgbuilds/edge/asdcontrol/PKGBUILD
+++ b/pkgbuilds/edge/asdcontrol/PKGBUILD
@@ -1,5 +1,6 @@
 # Maintainer: Ryan Hughes <ryan@omarchy.org>
 pkgname=asdcontrol
+epoch=1
 pkgver=0.6.0
 pkgrel=1
 pkgdesc="Control brightness on Apple Displays connected via USB-C"


### PR DESCRIPTION
Since [the original repository has been archived](https://github.com/nikosdion/asdcontrol) and [won’t receive further updates](https://github.com/nikosdion/asdcontrol/commit/0ee8bd576d4e93513027d713e688988cb0d827ef) (for now), I collected some pending fixes along with [this contribution](https://github.com/omakasui/asdcontrol/pull/1) and moved them into a [fork](https://github.com/omakasui/asdcontrol), including a proper release to avoid pointing directly to commits.

This should also make things easier to manage.