### PR TITLE
Add macbook8-spi-pxa2xx-nodma-dkms package

### DIFF
--- a/pkgbuilds/macbook8-spi-pxa2xx-nodma-dkms/.omarchy/package.json
+++ b/pkgbuilds/macbook8-spi-pxa2xx-nodma-dkms/.omarchy/package.json
@@ -1,0 +1,3 @@
+{
+  "source": "local"
+}

--- a/pkgbuilds/macbook8-spi-pxa2xx-nodma-dkms/Makefile
+++ b/pkgbuilds/macbook8-spi-pxa2xx-nodma-dkms/Makefile
@@ -1,0 +1,9 @@
+obj-m := spi_pxa2xx_pci_nodma.o
+spi_pxa2xx_pci_nodma-objs := spi-pxa2xx-pci-nodma.o
+EXTRA_CFLAGS += -I$(src)
+
+all:
+	$(MAKE) -C /lib/modules/$(KERNELRELEASE)/build M=$(PWD) modules
+
+clean:
+	$(MAKE) -C /lib/modules/$(KERNELRELEASE)/build M=$(PWD) clean

--- a/pkgbuilds/macbook8-spi-pxa2xx-nodma-dkms/PKGBUILD
+++ b/pkgbuilds/macbook8-spi-pxa2xx-nodma-dkms/PKGBUILD
@@ -1,0 +1,34 @@
+# Maintainer: Alvaro Fraguas <alvarofraguas@gmail.com>
+_pkgbase=spi-pxa2xx-pci-nodma
+pkgname=macbook8-spi-pxa2xx-nodma-dkms
+pkgver=1.0
+pkgrel=1
+pkgdesc="Patched SPI PXA2xx PCI driver forcing PIO mode for MacBook8,1 Wildcat Point GSPI (8086:9ce6)"
+arch=('x86_64')
+url="https://github.com/basecamp/omarchy"
+license=('GPL-2.0-only')
+depends=('dkms' 'linux-headers')
+makedepends=()
+conflicts=('spi_pxa2xx_pci' 'macbook12-spi-driver-dkms')
+provides=('spi_pxa2xx_pci_nodma')
+source=("spi-pxa2xx-pci-nodma.c"
+        "spi-pxa2xx.h"
+        "Makefile"
+        "dkms.conf"
+        "macbook8-spi-nodma.conf")
+sha256sums=('ffe04ab2c5d51db36b39eba05ace5faaf33d5004f46608f4fa06343ba873038b'
+            '011221bcaae0b8ca2634c3b2624b83b8a7bd94b37427fcd95548b3db705d5ec3'
+            'f9d1e48f6a18168105a6f6991953125cdf41457de178c00fe7378376ec11f12f'
+            '9fb4503571118d6e128387b99e371fc1f9401fe192f215c5b976a81c4937c514'
+            '455d3a9985928a5abc21452ca70c845d9203ec26c8826962607cdfbc2f34d86c')
+
+package() {
+    # DKMS source files
+    install -Dm644 "${srcdir}/spi-pxa2xx-pci-nodma.c" "${pkgdir}/usr/src/${_pkgbase}-${pkgver}/spi-pxa2xx-pci-nodma.c"
+    install -Dm644 "${srcdir}/spi-pxa2xx.h" "${pkgdir}/usr/src/${_pkgbase}-${pkgver}/spi-pxa2xx.h"
+    install -Dm644 "${srcdir}/Makefile" "${pkgdir}/usr/src/${_pkgbase}-${pkgver}/Makefile"
+    install -Dm644 "${srcdir}/dkms.conf" "${pkgdir}/usr/src/${_pkgbase}-${pkgver}/dkms.conf"
+
+    # Modprobe blacklist: prevent the in-tree spi_pxa2xx_pci from claiming this device
+    install -Dm644 "${srcdir}/macbook8-spi-nodma.conf" "${pkgdir}/usr/lib/modprobe.d/macbook8-spi-nodma.conf"
+}

--- a/pkgbuilds/macbook8-spi-pxa2xx-nodma-dkms/dkms.conf
+++ b/pkgbuilds/macbook8-spi-pxa2xx-nodma-dkms/dkms.conf
@@ -1,0 +1,6 @@
+PACKAGE_NAME="spi-pxa2xx-pci-nodma"
+PACKAGE_VERSION="1.0"
+BUILT_MODULE_NAME[0]="spi_pxa2xx_pci_nodma"
+BUILT_MODULE_LOCATION[0]="."
+DEST_MODULE_LOCATION[0]="/kernel/drivers/spi"
+AUTOINSTALL="yes"

--- a/pkgbuilds/macbook8-spi-pxa2xx-nodma-dkms/macbook8-spi-nodma.conf
+++ b/pkgbuilds/macbook8-spi-pxa2xx-nodma-dkms/macbook8-spi-nodma.conf
@@ -1,0 +1,5 @@
+# MacBook8,1 SPI keyboard/trackpad fix:
+# Blacklist the in-tree spi_pxa2xx_pci so our PIO-mode version
+# (spi_pxa2xx_pci_nodma) binds to the Wildcat Point GSPI instead.
+blacklist spi_pxa2xx_pci
+install spi_pxa2xx_pci /bin/true

--- a/pkgbuilds/macbook8-spi-pxa2xx-nodma-dkms/spi-pxa2xx-pci-nodma.c
+++ b/pkgbuilds/macbook8-spi-pxa2xx-nodma-dkms/spi-pxa2xx-pci-nodma.c
@@ -1,0 +1,351 @@
+// SPDX-License-Identifier: GPL-2.0-only
+/*
+ * PCI glue driver for SPI PXA2xx compatible controllers.
+ * CE4100's SPI device is more or less the same one as found on PXA.
+ *
+ * Copyright (C) 2016, 2021 Intel Corporation
+ */
+#include <linux/clk-provider.h>
+#include <linux/device.h>
+#include <linux/err.h>
+#include <linux/module.h>
+#include <linux/pci.h>
+#include <linux/pm.h>
+#include <linux/pm_runtime.h>
+#include <linux/sprintf.h>
+#include <linux/string.h>
+#include <linux/types.h>
+
+#include <linux/dmaengine.h>
+#include <linux/platform_data/dma-dw.h>
+
+#include "spi-pxa2xx.h"
+
+#define PCI_DEVICE_ID_INTEL_QUARK_X1000		0x0935
+#define PCI_DEVICE_ID_INTEL_BYT			0x0f0e
+#define PCI_DEVICE_ID_INTEL_MRFLD		0x1194
+#define PCI_DEVICE_ID_INTEL_BSW0		0x228e
+#define PCI_DEVICE_ID_INTEL_BSW1		0x2290
+#define PCI_DEVICE_ID_INTEL_BSW2		0x22ac
+#define PCI_DEVICE_ID_INTEL_CE4100		0x2e6a
+#define PCI_DEVICE_ID_INTEL_LPT0_0		0x9c65
+#define PCI_DEVICE_ID_INTEL_LPT0_1		0x9c66
+#define PCI_DEVICE_ID_INTEL_LPT1_0		0x9ce5
+#define PCI_DEVICE_ID_INTEL_LPT1_1		0x9ce6
+
+struct pxa_spi_info {
+	int (*setup)(struct pci_dev *pdev, struct pxa2xx_spi_controller *c);
+};
+
+static struct dw_dma_slave byt_tx_param = { .dst_id = 0 };
+static struct dw_dma_slave byt_rx_param = { .src_id = 1 };
+
+static struct dw_dma_slave mrfld3_tx_param = { .dst_id = 15 };
+static struct dw_dma_slave mrfld3_rx_param = { .src_id = 14 };
+static struct dw_dma_slave mrfld5_tx_param = { .dst_id = 13 };
+static struct dw_dma_slave mrfld5_rx_param = { .src_id = 12 };
+static struct dw_dma_slave mrfld6_tx_param = { .dst_id = 11 };
+static struct dw_dma_slave mrfld6_rx_param = { .src_id = 10 };
+
+static struct dw_dma_slave bsw0_tx_param = { .dst_id = 0 };
+static struct dw_dma_slave bsw0_rx_param = { .src_id = 1 };
+static struct dw_dma_slave bsw1_tx_param = { .dst_id = 6 };
+static struct dw_dma_slave bsw1_rx_param = { .src_id = 7 };
+static struct dw_dma_slave bsw2_tx_param = { .dst_id = 8 };
+static struct dw_dma_slave bsw2_rx_param = { .src_id = 9 };
+
+static struct dw_dma_slave lpt1_tx_param = { .dst_id = 0 };
+static struct dw_dma_slave lpt1_rx_param = { .src_id = 1 };
+static struct dw_dma_slave lpt0_tx_param = { .dst_id = 2 };
+static struct dw_dma_slave lpt0_rx_param = { .src_id = 3 };
+
+static void pxa2xx_spi_pci_clk_unregister(void *clk)
+{
+	clk_unregister(clk);
+}
+
+static int pxa2xx_spi_pci_clk_register(struct pci_dev *dev, struct ssp_device *ssp,
+				       unsigned long rate)
+{
+	char buf[40];
+
+	snprintf(buf, sizeof(buf), "pxa2xx-spi.%d", ssp->port_id);
+	ssp->clk = clk_register_fixed_rate(&dev->dev, buf, NULL, 0, rate);
+	if (IS_ERR(ssp->clk))
+		return PTR_ERR(ssp->clk);
+
+	return devm_add_action_or_reset(&dev->dev, pxa2xx_spi_pci_clk_unregister, ssp->clk);
+}
+
+static bool lpss_dma_filter(struct dma_chan *chan, void *param)
+{
+	struct dw_dma_slave *dws = param;
+
+	if (dws->dma_dev != chan->device->dev)
+		return false;
+
+	chan->private = dws;
+	return true;
+}
+
+static void lpss_dma_put_device(void *dma_dev)
+{
+	pci_dev_put(dma_dev);
+}
+
+static int lpss_spi_setup(struct pci_dev *dev, struct pxa2xx_spi_controller *c)
+{
+	struct ssp_device *ssp = &c->ssp;
+	struct dw_dma_slave *tx, *rx;
+	struct pci_dev *dma_dev;
+	int ret;
+
+	switch (dev->device) {
+	case PCI_DEVICE_ID_INTEL_BYT:
+		ssp->type = LPSS_BYT_SSP;
+		ssp->port_id = 0;
+		c->tx_param = &byt_tx_param;
+		c->rx_param = &byt_rx_param;
+		break;
+	case PCI_DEVICE_ID_INTEL_BSW0:
+		ssp->type = LPSS_BSW_SSP;
+		ssp->port_id = 0;
+		c->tx_param = &bsw0_tx_param;
+		c->rx_param = &bsw0_rx_param;
+		break;
+	case PCI_DEVICE_ID_INTEL_BSW1:
+		ssp->type = LPSS_BSW_SSP;
+		ssp->port_id = 1;
+		c->tx_param = &bsw1_tx_param;
+		c->rx_param = &bsw1_rx_param;
+		break;
+	case PCI_DEVICE_ID_INTEL_BSW2:
+		ssp->type = LPSS_BSW_SSP;
+		ssp->port_id = 2;
+		c->tx_param = &bsw2_tx_param;
+		c->rx_param = &bsw2_rx_param;
+		break;
+	case PCI_DEVICE_ID_INTEL_LPT0_0:
+	case PCI_DEVICE_ID_INTEL_LPT1_0:
+		ssp->type = LPSS_LPT_SSP;
+		ssp->port_id = 0;
+		c->tx_param = &lpt0_tx_param;
+		c->rx_param = &lpt0_rx_param;
+		break;
+	case PCI_DEVICE_ID_INTEL_LPT0_1:
+	case PCI_DEVICE_ID_INTEL_LPT1_1:
+		ssp->type = LPSS_LPT_SSP;
+		ssp->port_id = 1;
+		c->tx_param = &lpt1_tx_param;
+		c->rx_param = &lpt1_rx_param;
+		break;
+	default:
+		return -ENODEV;
+	}
+
+	c->num_chipselect = 1;
+
+	ret = pxa2xx_spi_pci_clk_register(dev, ssp, 50000000);
+	if (ret)
+		return ret;
+
+	dma_dev = pci_get_slot(dev->bus, PCI_DEVFN(PCI_SLOT(dev->devfn), 0));
+	ret = devm_add_action_or_reset(&dev->dev, lpss_dma_put_device, dma_dev);
+	if (ret)
+		return ret;
+
+	tx = c->tx_param;
+	tx->dma_dev = &dma_dev->dev;
+	tx->m_master = 0;
+	tx->p_master = 1;
+
+	rx = c->rx_param;
+	rx->dma_dev = &dma_dev->dev;
+	rx->m_master = 0;
+	rx->p_master = 1;
+
+	/* MacBook8,1 GSPI: disable DMA, use IRQ-polled PIO mode */
+	c->dma_filter = NULL;
+	c->dma_burst_size = 0;
+	c->enable_dma = 0;
+	return 0;
+}
+
+static const struct pxa_spi_info lpss_info_config = {
+	.setup = lpss_spi_setup,
+};
+
+static int ce4100_spi_setup(struct pci_dev *dev, struct pxa2xx_spi_controller *c)
+{
+	struct ssp_device *ssp = &c->ssp;
+
+	ssp->type = PXA25x_SSP;
+	ssp->port_id = dev->devfn;
+	c->num_chipselect = dev->devfn;
+
+	return pxa2xx_spi_pci_clk_register(dev, ssp, 3686400);
+}
+
+static const struct pxa_spi_info ce4100_info_config = {
+	.setup = ce4100_spi_setup,
+};
+
+static int mrfld_spi_setup(struct pci_dev *dev, struct pxa2xx_spi_controller *c)
+{
+	struct ssp_device *ssp = &c->ssp;
+	struct dw_dma_slave *tx, *rx;
+	struct pci_dev *dma_dev;
+	int ret;
+
+	ssp->type = MRFLD_SSP;
+
+	switch (PCI_FUNC(dev->devfn)) {
+	case 0:
+		ssp->port_id = 3;
+		c->num_chipselect = 1;
+		c->tx_param = &mrfld3_tx_param;
+		c->rx_param = &mrfld3_rx_param;
+		break;
+	case 1:
+		ssp->port_id = 5;
+		c->num_chipselect = 4;
+		c->tx_param = &mrfld5_tx_param;
+		c->rx_param = &mrfld5_rx_param;
+		break;
+	case 2:
+		ssp->port_id = 6;
+		c->num_chipselect = 1;
+		c->tx_param = &mrfld6_tx_param;
+		c->rx_param = &mrfld6_rx_param;
+		break;
+	default:
+		return -ENODEV;
+	}
+
+	ret = pxa2xx_spi_pci_clk_register(dev, ssp, 25000000);
+	if (ret)
+		return ret;
+
+	dma_dev = pci_get_slot(dev->bus, PCI_DEVFN(21, 0));
+	ret = devm_add_action_or_reset(&dev->dev, lpss_dma_put_device, dma_dev);
+	if (ret)
+		return ret;
+
+	tx = c->tx_param;
+	tx->dma_dev = &dma_dev->dev;
+
+	rx = c->rx_param;
+	rx->dma_dev = &dma_dev->dev;
+
+	c->dma_filter = lpss_dma_filter;
+	c->dma_burst_size = 8;
+	c->enable_dma = 1;
+	return 0;
+}
+
+static const struct pxa_spi_info mrfld_info_config = {
+	.setup = mrfld_spi_setup,
+};
+
+static int qrk_spi_setup(struct pci_dev *dev, struct pxa2xx_spi_controller *c)
+{
+	struct ssp_device *ssp = &c->ssp;
+
+	ssp->type = QUARK_X1000_SSP;
+	ssp->port_id = dev->devfn;
+	c->num_chipselect = 1;
+
+	return pxa2xx_spi_pci_clk_register(dev, ssp, 50000000);
+}
+
+static const struct pxa_spi_info qrk_info_config = {
+	.setup = qrk_spi_setup,
+};
+
+static int pxa2xx_spi_pci_probe(struct pci_dev *dev,
+		const struct pci_device_id *ent)
+{
+	const struct pxa_spi_info *info;
+	int ret;
+	struct pxa2xx_spi_controller *pdata;
+	struct ssp_device *ssp;
+
+	ret = pcim_enable_device(dev);
+	if (ret)
+		return ret;
+
+	pdata = devm_kzalloc(&dev->dev, sizeof(*pdata), GFP_KERNEL);
+	if (!pdata)
+		return -ENOMEM;
+
+	ssp = &pdata->ssp;
+	ssp->dev = &dev->dev;
+	ssp->phys_base = pci_resource_start(dev, 0);
+	ssp->mmio_base = pcim_iomap_region(dev, 0, "PXA2xx SPI");
+	if (IS_ERR(ssp->mmio_base))
+		return PTR_ERR(ssp->mmio_base);
+
+	info = (struct pxa_spi_info *)ent->driver_data;
+	ret = info->setup(dev, pdata);
+	if (ret)
+		return ret;
+
+	pci_set_master(dev);
+
+	ret = pci_alloc_irq_vectors(dev, 1, 1, PCI_IRQ_ALL_TYPES);
+	if (ret < 0)
+		return ret;
+	ssp->irq = pci_irq_vector(dev, 0);
+
+	ret = pxa2xx_spi_probe(&dev->dev, ssp, pdata);
+	if (ret)
+		return ret;
+
+	pm_runtime_set_autosuspend_delay(&dev->dev, 50);
+	pm_runtime_use_autosuspend(&dev->dev);
+	pm_runtime_put_autosuspend(&dev->dev);
+	pm_runtime_allow(&dev->dev);
+
+	return 0;
+}
+
+static void pxa2xx_spi_pci_remove(struct pci_dev *dev)
+{
+	pm_runtime_forbid(&dev->dev);
+	pm_runtime_get_noresume(&dev->dev);
+
+	pxa2xx_spi_remove(&dev->dev);
+}
+
+static const struct pci_device_id pxa2xx_spi_pci_devices[] = {
+	{ PCI_DEVICE_DATA(INTEL, QUARK_X1000, &qrk_info_config) },
+	{ PCI_DEVICE_DATA(INTEL, BYT, &lpss_info_config) },
+	{ PCI_DEVICE_DATA(INTEL, MRFLD, &mrfld_info_config) },
+	{ PCI_DEVICE_DATA(INTEL, BSW0, &lpss_info_config) },
+	{ PCI_DEVICE_DATA(INTEL, BSW1, &lpss_info_config) },
+	{ PCI_DEVICE_DATA(INTEL, BSW2, &lpss_info_config) },
+	{ PCI_DEVICE_DATA(INTEL, CE4100, &ce4100_info_config) },
+	{ PCI_DEVICE_DATA(INTEL, LPT0_0, &lpss_info_config) },
+	{ PCI_DEVICE_DATA(INTEL, LPT0_1, &lpss_info_config) },
+	{ PCI_DEVICE_DATA(INTEL, LPT1_0, &lpss_info_config) },
+	{ PCI_DEVICE_DATA(INTEL, LPT1_1, &lpss_info_config) },
+	{ }
+};
+MODULE_DEVICE_TABLE(pci, pxa2xx_spi_pci_devices);
+
+static struct pci_driver pxa2xx_spi_pci_driver = {
+	.name           = "pxa2xx_spi_pci",
+	.id_table       = pxa2xx_spi_pci_devices,
+	.driver = {
+		.pm	= pm_ptr(&pxa2xx_spi_pm_ops),
+	},
+	.probe          = pxa2xx_spi_pci_probe,
+	.remove         = pxa2xx_spi_pci_remove,
+};
+
+module_pci_driver(pxa2xx_spi_pci_driver);
+
+MODULE_DESCRIPTION("CE4100/LPSS PCI-SPI glue code for PXA's driver");
+MODULE_LICENSE("GPL v2");
+MODULE_IMPORT_NS("SPI_PXA2xx");
+MODULE_AUTHOR("Sebastian Andrzej Siewior <bigeasy@linutronix.de>");

--- a/pkgbuilds/macbook8-spi-pxa2xx-nodma-dkms/spi-pxa2xx.h
+++ b/pkgbuilds/macbook8-spi-pxa2xx-nodma-dkms/spi-pxa2xx.h
@@ -1,0 +1,141 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+/*
+ * Copyright (C) 2005 Stephen Street / StreetFire Sound Labs
+ * Copyright (C) 2013, 2021 Intel Corporation
+ */
+
+#ifndef SPI_PXA2XX_H
+#define SPI_PXA2XX_H
+
+#include <linux/dmaengine.h>
+#include <linux/irqreturn.h>
+#include <linux/types.h>
+#include <linux/sizes.h>
+
+#include <linux/pxa2xx_ssp.h>
+
+struct device;
+struct gpio_desc;
+
+/*
+ * The platform data for SSP controller devices
+ * (resides in device.platform_data).
+ */
+struct pxa2xx_spi_controller {
+	u8 num_chipselect;
+	u8 enable_dma;
+	u8 dma_burst_size;
+	bool is_target;
+
+	/* DMA engine specific config */
+	dma_filter_fn dma_filter;
+	void *tx_param;
+	void *rx_param;
+
+	/* For non-PXA arches */
+	struct ssp_device ssp;
+};
+
+struct spi_controller;
+struct spi_device;
+struct spi_transfer;
+
+struct driver_data {
+	/* SSP Info */
+	struct ssp_device *ssp;
+
+	/* SPI framework hookup */
+	enum pxa_ssp_type ssp_type;
+	struct spi_controller *controller;
+
+	/* PXA hookup */
+	struct pxa2xx_spi_controller *controller_info;
+
+	/* SSP masks*/
+	u32 dma_cr1;
+	u32 int_cr1;
+	u32 clear_sr;
+	u32 mask_sr;
+
+	/* DMA engine support */
+	atomic_t dma_running;
+
+	/* Current transfer state info */
+	void *tx;
+	void *tx_end;
+	void *rx;
+	void *rx_end;
+	u8 n_bytes;
+	int (*write)(struct driver_data *drv_data);
+	int (*read)(struct driver_data *drv_data);
+	irqreturn_t (*transfer_handler)(struct driver_data *drv_data);
+
+	void __iomem *lpss_base;
+
+	/* Optional slave FIFO ready signal */
+	struct gpio_desc *gpiod_ready;
+};
+
+static inline u32 pxa2xx_spi_read(const struct driver_data *drv_data, u32 reg)
+{
+	return pxa_ssp_read_reg(drv_data->ssp, reg);
+}
+
+static inline void pxa2xx_spi_write(const struct driver_data *drv_data, u32 reg, u32 val)
+{
+	pxa_ssp_write_reg(drv_data->ssp, reg, val);
+}
+
+#define DMA_ALIGNMENT		8
+
+static inline int pxa25x_ssp_comp(const struct driver_data *drv_data)
+{
+	switch (drv_data->ssp_type) {
+	case PXA25x_SSP:
+	case CE4100_SSP:
+	case QUARK_X1000_SSP:
+		return 1;
+	default:
+		return 0;
+	}
+}
+
+static inline void clear_SSCR1_bits(const struct driver_data *drv_data, u32 bits)
+{
+	pxa2xx_spi_write(drv_data, SSCR1, pxa2xx_spi_read(drv_data, SSCR1) & ~bits);
+}
+
+static inline u32 read_SSSR_bits(const struct driver_data *drv_data, u32 bits)
+{
+	return pxa2xx_spi_read(drv_data, SSSR) & bits;
+}
+
+static inline void write_SSSR_CS(const struct driver_data *drv_data, u32 val)
+{
+	if (drv_data->ssp_type == CE4100_SSP ||
+	    drv_data->ssp_type == QUARK_X1000_SSP)
+		val |= read_SSSR_bits(drv_data, SSSR_ALT_FRM_MASK);
+
+	pxa2xx_spi_write(drv_data, SSSR, val);
+}
+
+extern int pxa2xx_spi_flush(struct driver_data *drv_data);
+
+#define MAX_DMA_LEN		SZ_64K
+#define DEFAULT_DMA_CR1		(SSCR1_TSRE | SSCR1_RSRE | SSCR1_TRAIL)
+
+extern irqreturn_t pxa2xx_spi_dma_transfer(struct driver_data *drv_data);
+extern int pxa2xx_spi_dma_prepare(struct driver_data *drv_data,
+				  struct spi_transfer *xfer);
+extern void pxa2xx_spi_dma_start(struct driver_data *drv_data);
+extern void pxa2xx_spi_dma_stop(struct driver_data *drv_data);
+extern int pxa2xx_spi_dma_setup(struct driver_data *drv_data);
+extern void pxa2xx_spi_dma_release(struct driver_data *drv_data);
+
+int pxa2xx_spi_probe(struct device *dev, struct ssp_device *ssp,
+		     struct pxa2xx_spi_controller *platform_info);
+void pxa2xx_spi_remove(struct device *dev);
+
+extern const struct dev_pm_ops pxa2xx_spi_pm_ops;
+
+#endif /* SPI_PXA2XX_H */


### PR DESCRIPTION
## Summary

Adds a DKMS package for MacBook8,1 (12", Early 2015) keyboard/trackpad support. The Wildcat Point GSPI controller (PCI `8086:9ce6`) on this hardware has a broken DMA handshake that causes all SPI transfers to time out. This patched version of `spi_pxa2xx_pci` forces PIO mode (`enable_dma=0`) for this PCI ID only, leaving DMA enabled for all other LPSS SPI devices.

Requires `irqpoll` on the kernel command line for the SPI IRQ handler to be serviced (since IO-APIC doesn't deliver IRQ 21 from this hardware).

Includes a modprobe blacklist to prevent the in-tree `spi_pxa2xx_pci` from claiming the device before our patched version.

Conflicts with `macbook12-spi-driver-dkms` (mutually exclusive; this machine uses the in-tree `applespi` driver instead of the macbook12 out-of-tree one).

Extracted from basecamp/omarchy#5563 as suggested by @dhh.

## Test plan

- [x] Built with `makepkg` successfully on Arch Linux 6.19.13-arch1-1
- [x] DKMS module compiles and installs (`dkms install spi-pxa2xx-pci-nodma/1.0`)
- [x] Module loads at boot via modprobe blacklist + AUTOINSTALL
- [x] Keyboard and trackpad work after lid close/reopen sleep cycle
- [x] `irqpoll` kernel parameter confirmed working
- [x] Conflicts with `macbook12-spi-driver-dkms` as expected