### PR TITLE
Fix: intl-ipu7-camera resume hook

### DIFF
--- a/pkgbuilds/intel-ipu7-camera/PKGBUILD
+++ b/pkgbuilds/intel-ipu7-camera/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=intel-ipu7-camera
 pkgver=1.0.3
-pkgrel=4
+pkgrel=5
 pkgdesc="Intel IPU7 MIPI camera stack for Hurrican/Performance (OV08X40 + hardware ISP)"
 arch=('x86_64')
 url="https://github.com/TsaiGaggery/hurrican_omarchy_enabling"

--- a/pkgbuilds/intel-ipu7-camera/PKGBUILD
+++ b/pkgbuilds/intel-ipu7-camera/PKGBUILD
@@ -1,8 +1,8 @@
 # Maintainer: Omarchy <packages@omarchy.org>
 
 pkgname=intel-ipu7-camera
-pkgver=1.0.3
-pkgrel=5
+pkgver=1.0.4
+pkgrel=1
 pkgdesc="Intel IPU7 MIPI camera stack for Hurrican/Performance (OV08X40 + hardware ISP)"
 arch=('x86_64')
 url="https://github.com/TsaiGaggery/hurrican_omarchy_enabling"

--- a/pkgbuilds/intel-ipu7-camera/camera-sleep-hook
+++ b/pkgbuilds/intel-ipu7-camera/camera-sleep-hook
@@ -2,21 +2,12 @@
 
 # Handle camera service around suspend/resume.
 #
-# On resume the IPU7 firmware re-authenticates (CSE authenticate_run),
-# but the ov08x40 sensor is not re-bound to the media-controller graph.
-# libcamhal then reports "No sensors available", icamerasrc fails to
-# register properties, and /dev/video50 stays empty — the camera looks
-# dead to every app until reboot.
+# v4l2-relayd must be stopped before suspend to avoid GStreamer crashes,
+# then restarted after resume once the camera hardware is ready.
 #
-# Workaround: after resume, unload + reload ov08x40 and intel_ipu7_isys
-# so isys re-probes the sensor via ipu_bridge.
-#
-# DO NOT unload intel_ipu7_isys pre-suspend: s2idle wake requires the
-# IPU7 driver to be attached, and unloading it before suspend hangs the
-# machine on wake.
-#
-# The post-resume work runs via systemd-run so it doesn't block the
-# lock-screen password prompt while modules settle.
+# Avoid unloading/reloading IPU7 kernel modules from the sleep hook. Module
+# reprobe during resume can hit fragile kernel PM paths and make wake less
+# reliable than a recoverable camera failure.
 
 case "$1" in
   pre)
@@ -24,12 +15,7 @@ case "$1" in
     ;;
   post)
     systemd-run --no-block --unit=camera-resume bash -c '
-      rmmod ov08x40 2>/dev/null || true
-      rmmod intel_ipu7_isys 2>/dev/null || true
-      sleep 1
-      modprobe intel_ipu7_isys 2>/dev/null
-      sleep 1
-      modprobe ov08x40 2>/dev/null
+      systemctl restart camera-init.service 2>/dev/null || true
       systemctl reset-failed v4l2-relayd@ipu7.service 2>/dev/null || true
       systemctl start v4l2-relayd@ipu7.service 2>/dev/null || true
     '

--- a/pkgbuilds/v4l2-relayd/0002-escape-optional-splashsrc-expansion.patch
+++ b/pkgbuilds/v4l2-relayd/0002-escape-optional-splashsrc-expansion.patch
@@ -1,0 +1,11 @@
+--- data/systemd/v4l2-relayd@.service.orig	2026-06-15 12:00:00.000000000 -0500
++++ data/systemd/v4l2-relayd@.service	2026-06-15 12:00:00.000000000 -0500
+@@ -14,7 +14,7 @@
+ ExecCondition=/usr/bin/test -n "$HEIGHT"
+ ExecCondition=/usr/bin/test -n "$FRAMERATE"
+ ExecCondition=/usr/bin/test -n "${CARD_LABEL}"
+-ExecStart=/bin/sh -c 'DEVICE=$(grep -l -m1 -E "^${CARD_LABEL}$" /sys/devices/virtual/video4linux/*/name | cut -d/ -f6); exec /usr/bin/v4l2-relayd -i "${VIDEOSRC}" $${SPLASHSRC:+-s "${SPLASHSRC}"} -o "appsrc name=appsrc caps=video/x-raw,format=${FORMAT},width=${WIDTH},height=${HEIGHT},framerate=${FRAMERATE} ! videoconvert ! v4l2sink name=v4l2sink device=/dev/$${DEVICE}" $EXTRA_OPTS'
++ExecStart=/bin/sh -c 'DEVICE=$(grep -l -m1 -E "^${CARD_LABEL}$" /sys/devices/virtual/video4linux/*/name | cut -d/ -f6); exec /usr/bin/v4l2-relayd -i "${VIDEOSRC}" $${SPLASHSRC:+-s "$${SPLASHSRC}"} -o "appsrc name=appsrc caps=video/x-raw,format=${FORMAT},width=${WIDTH},height=${HEIGHT},framerate=${FRAMERATE} ! videoconvert ! v4l2sink name=v4l2sink device=/dev/$${DEVICE}" $EXTRA_OPTS'
+ Restart=always
+ PrivateNetwork=yes
+ PrivateTmp=yes

--- a/pkgbuilds/v4l2-relayd/PKGBUILD
+++ b/pkgbuilds/v4l2-relayd/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=v4l2-relayd
 pkgver=0.2.0
-pkgrel=2.1
+pkgrel=2.2
 pkgdesc="Plays gstreamer sources into v4l2loopback devices."
 arch=('x86_64')
 url="https://gitlab.com/vicamo/v4l2-relayd"
@@ -16,13 +16,16 @@ depends=(
 )
 makedepends=('git')
 source=("https://gitlab.com/vicamo/v4l2-relayd/-/archive/upstream/${pkgver}/v4l2-relayd-upstream-${pkgver}.tar.gz"
-        "0001-reset-output-on-idle.patch")
+        "0001-reset-output-on-idle.patch"
+        "0002-escape-optional-splashsrc-expansion.patch")
 sha256sums=('0c063edf18dcc6edcdef46e695128cfc2b2d60964ea8538c7e79a2454310c53d'
+            'SKIP'
             'SKIP')
 
 prepare() {
   cd "$srcdir/${pkgname}-upstream-${pkgver}"
   patch -p0 < "$srcdir/0001-reset-output-on-idle.patch"
+  patch -p0 < "$srcdir/0002-escape-optional-splashsrc-expansion.patch"
 }
 
 build() {


### PR DESCRIPTION
On an XPS 14 & 16 [Panther Lake] system running `linux-ptl 7.0.11.arch1-1`, the machine occasionally fails to wake from suspend or is laggy. 

Post issue, the journal shows the previous boot entered `s2idle` suspend and never logged a resume:

```text
2026-06-14T09:57:22-05:00 saber systemd-logind[1083]: Lid closed.
2026-06-14T09:57:22-05:00 saber systemd-logind[1083]: Suspending...
2026-06-14T09:57:23-05:00 saber systemd[1]: Stopping v4l2-relay daemon service for ipu7...
2026-06-14T09:57:23-05:00 saber systemd[1]: v4l2-relayd@ipu7.service: Deactivated successfully.
2026-06-14T09:57:23-05:00 saber systemd[1]: Stopped v4l2-relay daemon service for ipu7.
2026-06-14T09:57:23-05:00 saber systemd-sleep[41205]: Performing sleep operation 'suspend'...
2026-06-14T09:57:23-05:00 saber kernel: PM: suspend entry (s2idle)
```

The next entry is the forced reboot the following morning:

```text
2026-06-15T08:31:10-05:00 saber reboot: system boot 7.0.11-arch1-1-ptl
```

There is no matching `PM: suspend exit`, no `System returned from sleep`, and no post-resume userspace log for this failed suspend. That points to a kernel/firmware/device resume hang rather than just a compositor or display-session failure.

## Relevant Package Behavior

The installed `/usr/lib/systemd/system-sleep/camera-sleep-hook` is sourced from this package:

```text
pkgbuilds/intel-ipu7-camera/camera-sleep-hook
```

Current `post)` resume behavior unloads and reloads camera kernel modules automatically:

```bash
rmmod ov08x40 2>/dev/null || true
rmmod intel_ipu7_isys 2>/dev/null || true
sleep 1
modprobe intel_ipu7_isys 2>/dev/null
sleep 1
modprobe ov08x40 2>/dev/null
systemctl reset-failed v4l2-relayd@ipu7.service 2>/dev/null || true
systemctl start v4l2-relayd@ipu7.service 2>/dev/null || true
```

This logic was introduced by commit `07f5231 Fix the resume-from-sleep case`, which changed the older behavior from restarting `camera-init.service` to directly reprobeing `intel_ipu7_isys` and `ov08x40`.

## Evidence Implicating The Module Reprobe Path

Earlier on the same boot, a successful lid-open resume ran `camera-resume.service` and hit kernel warnings in the exact module reprobe path:

```text
2026-06-14T09:14:24-05:00 saber kernel: PM: suspend exit
2026-06-14T09:14:24-05:00 saber systemd-run[31515]: Running as unit: camera-resume.service
2026-06-14T09:14:24-05:00 saber systemd[1]: Started [systemd-run] /usr/bin/bash -c "
      rmmod ov08x40 2>/dev/null || true
      rmmod intel_ipu7_isys 2>/dev/null || true
      sleep 1
      modprobe intel_ipu7_isys 2>/dev/null
      sleep 1
      modprobe ov08x40 2>/dev/null
      systemctl reset-failed v4l2-relayd@ipu7.service 2>/dev/null || true
      systemctl start v4l2-relayd@ipu7.service 2>/dev/null || true
    ".
2026-06-14T09:14:26-05:00 saber kernel: modprobe: page allocation failure: order:10, mode:0x40dc0(GFP_KERNEL|__GFP_ZERO|__GFP_COMP), nodemask=(null),cpuset=camera-resume.service,mems_allowed=0
2026-06-14T09:14:26-05:00 saber kernel: intel_ipu7_isys.isys intel_ipu7.isys.40: probe with driver intel_ipu7_isys.isys failed with error -12
2026-06-14T09:14:26-05:00 saber kernel: WARNING: kernel/power/qos.c:301 at cpu_latency_qos_update_request+0x2b/0xe0, CPU#1: kworker/u65:15/31455
2026-06-14T09:14:27-05:00 saber kernel: WARNING: drivers/media/mc/mc-entity.c:1145 at media_create_pad_link+0x169/0x1b0 [mc], CPU#10: modprobe/31811
2026-06-14T09:14:27-05:00 saber kernel: auxiliary intel_ipu7.isys.40: can't create link
```

The kernel was tainted by the out-of-tree/unsigned IPU modules during this sequence:

```text
Tainted: [W]=WARN, [O]=OOT_MODULE, [E]=UNSIGNED_MODULE
Unloaded tainted modules: intel_ipu7_isys(OE):3 [last unloaded: intel_ipu7_isys(OE)]
```

This does not prove the later hard hang was caused by the camera hook, because the failed resume did not produce logs. However, it proves the current hook exercises an unstable kernel power-management path on resume.

## Current Hook Comment Is Also A Warning Sign

The hook currently says:

```text
DO NOT unload intel_ipu7_isys pre-suspend: s2idle wake requires the
IPU7 driver to be attached, and unloading it before suspend hangs the
machine on wake.
```

That acknowledges `intel_ipu7_isys` attachment state can affect `s2idle` wake reliability. Given the observed PM warnings and allocation failure from post-resume reprobe, the safest package behavior should avoid automatic kernel module churn in the system sleep path.

## Proposed Fix Direction

Prioritize reliable suspend/resume over automatic camera recovery:

1. Keep stopping `v4l2-relayd@ipu7.service` in the `pre)` hook.
2. Remove automatic `rmmod` / `modprobe` of `ov08x40` and `intel_ipu7_isys` from the `post)` hook.
3. In `post)`, only restart userspace camera services, for example:

```bash
systemctl restart camera-init.service 2>/dev/null || true
systemctl reset-failed v4l2-relayd@ipu7.service 2>/dev/null || true
systemctl start v4l2-relayd@ipu7.service 2>/dev/null || true
```
