### PR TITLE
Add btop-xe package for Intel xe GPUs

### DIFF
--- a/pkgbuilds/btop-xe/.omarchy/package.json
+++ b/pkgbuilds/btop-xe/.omarchy/package.json
@@ -1,0 +1,3 @@
+{
+  "source": "local"
+}

--- a/pkgbuilds/btop-xe/PKGBUILD
+++ b/pkgbuilds/btop-xe/PKGBUILD
@@ -1,6 +1,6 @@
 pkgname=btop-xe
 pkgver=1.4.7.xe.76530c8
-pkgrel=1
+pkgrel=2
 pkgdesc='btop with Intel Xe GPU support'
 arch=('x86_64')
 url='https://github.com/aristocratos/btop'
@@ -12,8 +12,19 @@ provides=('btop')
 conflicts=('btop')
 install=btop-xe.install
 options=('!debug')
-source=("btop::git+https://github.com/deveworld/btop.git#commit=76530c80dd6184ccb72d7048c2589afdc4bdee52")
-sha256sums=('SKIP')
+source=(
+  "btop::git+https://github.com/deveworld/btop.git#commit=76530c80dd6184ccb72d7048c2589afdc4bdee52"
+  "prefer-gtidle-for-xe-utilization.patch"
+)
+sha256sums=(
+  'SKIP'
+  '53e0b555589a3333c0e40430988c62221becbeba02ed8c69ca69d452c9439371'
+)
+
+prepare() {
+  cd btop
+  patch -Np1 -i "$srcdir/prefer-gtidle-for-xe-utilization.patch"
+}
 
 build() {
   cd btop

--- a/pkgbuilds/btop-xe/PKGBUILD
+++ b/pkgbuilds/btop-xe/PKGBUILD
@@ -1,0 +1,26 @@
+pkgname=btop-xe
+pkgver=1.4.7.xe.76530c8
+pkgrel=1
+pkgdesc='btop with Intel Xe GPU support'
+arch=('x86_64')
+url='https://github.com/aristocratos/btop'
+license=('Apache-2.0')
+depends=('glibc' 'hicolor-icon-theme' 'libgcc' 'libstdc++' 'libcap')
+makedepends=('git' 'gcc' 'make' 'libdrm' 'libpciaccess')
+optdepends=('rocm-smi-lib: AMD GPU support')
+provides=('btop')
+conflicts=('btop')
+install=btop-xe.install
+options=('!debug')
+source=("btop::git+https://github.com/deveworld/btop.git#commit=76530c80dd6184ccb72d7048c2589afdc4bdee52")
+sha256sums=('SKIP')
+
+build() {
+  cd btop
+  make STATIC= GPU_SUPPORT=true RSMI_STATIC= STRIP=true
+}
+
+package() {
+  cd btop
+  make PREFIX=/usr DESTDIR="$pkgdir" install
+}

--- a/pkgbuilds/btop-xe/btop-xe.install
+++ b/pkgbuilds/btop-xe/btop-xe.install
@@ -1,0 +1,7 @@
+post_install() {
+  setcap 'cap_perfmon=+ep cap_dac_read_search=+ep' /usr/bin/btop 2>/dev/null || true
+}
+
+post_upgrade() {
+  post_install
+}

--- a/pkgbuilds/btop-xe/prefer-gtidle-for-xe-utilization.patch
+++ b/pkgbuilds/btop-xe/prefer-gtidle-for-xe-utilization.patch
@@ -1,0 +1,32 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Kristoffer Haugland <stappmus@gmail.com>
+Date: Thu, 25 Jun 2026 23:48:00 +0200
+Subject: [PATCH] Prefer Xe gtidle before fdinfo utilization
+
+The fdinfo collector walks /proc/*/fd and /proc/*/fdinfo on each sample.
+That is much more expensive than sysfs gtidle counters on process-heavy
+desktops. Prefer gtidle when the kernel exposes it, and keep fdinfo as a
+fallback for systems without gtidle.
+---
+ src/linux/btop_collect.cpp | 6 ++++--
+ 1 file changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/src/linux/btop_collect.cpp b/src/linux/btop_collect.cpp
+index 57a2f2d..e816404 100644
+--- a/src/linux/btop_collect.cpp
++++ b/src/linux/btop_collect.cpp
+@@ -2487,8 +2487,10 @@ namespace Gpu {
+ 				st.mem_total = mem_total;
+ 			}
+ 
+-			// Test fdinfo availability
+-			if (not st.pci_slot.empty()) {
++			// Prefer gtidle when the kernel exposes it. fdinfo scans /proc every
++			// sample and is much more expensive on process-heavy desktops.
++			// Systems without gtidle still use fdinfo when available.
++			if (not st.pci_slot.empty() and st.gt_idle.empty()) {
+ 				FdinfoCycles test_cycles = collect_fdinfo_cycles(st.pci_slot);
+ 				st.fdinfo_probe_enabled = true;
+ 				st.fdinfo_next_probe_ns = 0;
+-- 
+2.50.0


### PR DESCRIPTION
## Summary

Add a temporary `btop-xe` package that provides `btop` with Intel `xe` GPU support while upstream/Arch `btop` is still missing support for Xe-driver Intel GPUs.

This keeps the normal btop GPU build enabled (`GPU_SUPPORT=true`) and only swaps in a Xe-capable btop build on systems that explicitly install `btop-xe`.

## Why

Intel Lunar Lake, Panther Lake, Battlemage, and future Intel GPUs use the `xe` kernel driver instead of `i915`. Current Arch `extra/btop` does not detect these GPUs, so Omarchy laptops with Intel Xe GPUs show no GPU usage/frequency in btop.

Upstream context:

- https://github.com/aristocratos/btop/issues/1407
- https://github.com/aristocratos/btop/pull/1457

## Package

- `pkgname=btop-xe`
- `provides=('btop')`
- `conflicts=('btop')`
- installs `/usr/bin/btop`
- restores `cap_perfmon` and `cap_dac_read_search` after install/upgrade
- pinned to the tested Xe-support commit `76530c80dd6184ccb72d7048c2589afdc4bdee52`

## Tested

Built locally with `makepkg -f --clean --cleanbuild`.

On Intel Panther Lake / Arc B390 using the `xe` driver:

```text
/sys/class/drm/card0/device/uevent: DRIVER=xe
/sys/bus/event_source/devices/xe_0000_00_02.0 exists
```

After installing the same build locally:

```text
btop version: 1.4.7+76530c8
Configured with: make STATIC= GPU_SUPPORT=true RSMI_STATIC=
/usr/bin/btop cap_dac_read_search,cap_perfmon=ep
```

`btop -d` reports:

```text
Xe: Using fdinfo for GPU utilization (PCI: 0000:00:02.0)
```

GPU total usage, RC/MC engine usage, and frequency render in btop.

## Notes

This package should be removed once upstream btop and Arch `extra/btop` include Intel `xe` support.

AI disclosure: this PR was prepared with AI assistance and manually tested on real Panther Lake hardware.
