### PR TITLE
Fix IPU7 PSYS camera support on Linux 7.1

### DIFF
--- a/pkgbuilds/intel-ipu7-camera/0004-ipu7-psys-register-device-bus.patch
+++ b/pkgbuilds/intel-ipu7-camera/0004-ipu7-psys-register-device-bus.patch
@@ -1,0 +1,71 @@
+From 77e3a0065697314cc7437a6eefd7e0d36ab06a4b Mon Sep 17 00:00:00 2001
+From: Thadeu Tucci <thadeutucci@gmail.com>
+Date: Thu, 9 Jul 2026 12:02:24 -0300
+Subject: [PATCH] media: intel/ipu7: psys: register bus before adding the psys
+ device
+
+The psys driver defines a custom "intel-ipu7-psys" bus_type, assigns it
+to the psys device (psys->dev.bus = &ipu7_psys_bus) and then calls
+device_register(), but it never calls bus_register() for that bus.
+
+Older kernels tolerated registering a device on an unregistered bus, but
+since Linux 7.1 bus_add_device() rejects it, so probe fails:
+
+  bus_add_device: cannot add device 'ipu7-psys0' to unregistered bus 'intel-ipu7-psys'
+  intel-ipu7-psys ipu7-psys0: psys device_register failed
+  intel_ipu7_psys.psys intel_ipu7.psys.40: probe with driver intel_ipu7_psys.psys failed with error -22
+
+As a result /dev/ipu7-psys0 is never created and the userspace camera
+HAL cannot open the psys device, breaking the camera on IPU7 platforms
+(e.g. Panther Lake with ov08x40) for every capture application.
+
+Register the bus in module init before registering the auxiliary driver,
+and unregister it on exit, by replacing module_auxiliary_driver() with
+explicit module_init()/module_exit() hooks.
+
+Link: https://github.com/intel/ipu7-drivers/issues/52
+Link: https://github.com/intel/ipu7-drivers/issues/63
+Link: https://github.com/intel/ipu7-drivers/issues/79
+Link: https://github.com/intel/ipu7-drivers/pull/87
+Signed-off-by: Thadeu Tucci <thadeutucci@gmail.com>
+---
+ drivers/media/pci/intel/ipu7/psys/ipu-psys.c | 24 +++++++++++++++++++++++-
+ 1 file changed, 23 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/media/pci/intel/ipu7/psys/ipu-psys.c b/drivers/media/pci/intel/ipu7/psys/ipu-psys.c
+index d175e4e..73186e0 100644
+--- a/drivers/media/pci/intel/ipu7/psys/ipu-psys.c
++++ b/drivers/media/pci/intel/ipu7/psys/ipu-psys.c
+@@ -1539,7 +1539,29 @@ static struct auxiliary_driver ipu7_psys_driver = {
+ 	},
+ };
+ 
+-module_auxiliary_driver(ipu7_psys_driver);
++static int __init ipu7_psys_init(void)
++{
++	int ret;
++
++	ret = bus_register(&ipu7_psys_bus);
++	if (ret)
++		return ret;
++
++	ret = auxiliary_driver_register(&ipu7_psys_driver);
++	if (ret)
++		bus_unregister(&ipu7_psys_bus);
++
++	return ret;
++}
++
++static void __exit ipu7_psys_exit(void)
++{
++	auxiliary_driver_unregister(&ipu7_psys_driver);
++	bus_unregister(&ipu7_psys_bus);
++}
++
++module_init(ipu7_psys_init);
++module_exit(ipu7_psys_exit);
+ 
+ MODULE_AUTHOR("Bingbu Cao <bingbu.cao@intel.com>");
+ MODULE_AUTHOR("Qingwu Zhang <qingwu.zhang@intel.com>");
+-- 
+2.50.1

--- a/pkgbuilds/intel-ipu7-camera/PKGBUILD
+++ b/pkgbuilds/intel-ipu7-camera/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Omarchy <packages@omarchy.org>
 
 pkgname=intel-ipu7-camera
-pkgver=1.0.4
+pkgver=1.0.5
 pkgrel=1
 pkgdesc="Intel IPU7 MIPI camera stack for Hurrican/Performance (OV08X40 + hardware ISP)"
 arch=('x86_64')
@@ -43,6 +43,7 @@ source=(
   "ipu7-camera-bins::git+https://github.com/intel/ipu7-camera-bins.git#commit=${_ipu7_camera_bins_commit}"
   "ipu7-camera-hal::git+https://github.com/intel/ipu7-camera-hal.git#commit=${_ipu7_camera_hal_commit}"
   "icamerasrc::git+https://github.com/intel/icamerasrc.git#commit=${_icamerasrc_commit}"
+  "0004-ipu7-psys-register-device-bus.patch"
   "0003-icvs-set-rgbcamera_pwrup_host-0-for-Panther-Lake.patch"
   "dkms-ipu7-drivers.conf"
   "dkms-vision-drivers.conf"
@@ -61,13 +62,16 @@ source=(
   "v4l2-relayd-ipu7-override.conf"
 )
 sha256sums=(
-  'SKIP' 'SKIP' 'SKIP' 'SKIP' 'SKIP' 'SKIP'
+  'SKIP' 'SKIP' 'SKIP' 'SKIP' 'SKIP' 'SKIP' 'SKIP'
   'SKIP' 'SKIP' 'SKIP' 'SKIP' 'SKIP' 'SKIP'
   'SKIP' 'SKIP' 'SKIP' 'SKIP' 'SKIP' 'SKIP'
   'SKIP' 'SKIP' 'SKIP'
 )
 
 prepare() {
+  cd "${srcdir}/ipu7-drivers"
+  patch -Np1 -i "${srcdir}/0004-ipu7-psys-register-device-bus.patch"
+
   cd "${srcdir}/vision-drivers"
   git config user.email "build@localhost"
   git config user.name "Build"


### PR DESCRIPTION
## Summary

- backport Intel's pending IPU7 PSYS bus-registration fix to the driver revision pinned by `intel-ipu7-camera`
- apply the backport during `prepare()` and bump the Omarchy camera stack version to `1.0.5-1`
- retain the downstream patch only until the upstream fix is merged and the pinned driver commit includes it

## Root cause

The IPU7 PSYS driver assigns a custom `intel-ipu7-psys` bus to its character device but never registers that bus. Linux 7.1 rejects `device_register()` on the unregistered bus, producing:

```text
bus_add_device: cannot add device 'ipu7-psys0' to unregistered bus 'intel-ipu7-psys'
intel-ipu7-psys ipu7-psys0: psys device_register failed
intel_ipu7_psys.psys intel_ipu7.psys.40: probe with driver intel_ipu7_psys.psys failed with error -22
```

Without `/dev/ipu7-psys0`, CamHAL cannot initialize the hardware ISP and the internal camera stalls.

The backport registers the PSYS bus before the auxiliary driver and unregisters both in reverse order during module exit.

## Upstream status

This is a backport of the fix proposed in [intel/ipu7-drivers#87](https://github.com/intel/ipu7-drivers/pull/87), adapted to Omarchy's older pinned driver commit. The downstream patch can be removed after that PR merges and `_ipu7_drivers_commit` is updated to include it.

Related upstream reports:

- [intel/ipu7-drivers#52](https://github.com/intel/ipu7-drivers/issues/52)
- [intel/ipu7-drivers#63](https://github.com/intel/ipu7-drivers/issues/63)
- [intel/ipu7-drivers#79](https://github.com/intel/ipu7-drivers/issues/79)

## Validation

Tested on a Panther Lake Dell XPS with OV08X40 using `linux-ptl 7.1.3-arch1-1-ptl`:

- built the complete `intel-ipu7-camera 1.0.5-1` package successfully with `makepkg`
- installed the package and confirmed DKMS loaded the packaged `intel-ipu7-psys.ko.zst`
- confirmed `/dev/ipu7-psys0` and its compatibility symlink are created
- confirmed Chromium can acquire `/dev/video50`; an earlier isolated test captured 60 consecutive frames with exit status 0
- confirmed `v4l2-relayd@ipu7.service` remains active with no new PSYS or CamHAL errors
- confirmed WirePlumber exposes `Hardware ISP Camera (V4L2)`
- dry-ran the downstream patch against pinned IPU7 commit `a88b19096a738d0708742a78d6540d6d4a3021ff`
- verified the `PKGBUILD` has matching source and checksum array lengths
