### PR TITLE
Run package update pipeline hourly

### DIFF
--- a/.github/workflows/sync-aur.yml
+++ b/.github/workflows/sync-aur.yml
@@ -2,8 +2,8 @@ name: Sync AUR Packages
 
 on:
   schedule:
-    # Every 6 hours
-    - cron: '0 */6 * * *'
+    # Every hour
+    - cron: '0 * * * *'
   workflow_dispatch:
     inputs:
       packages:

--- a/README.md
+++ b/README.md
@@ -385,13 +385,13 @@ The repository includes GitHub workflows and systemd services for automated rele
 
 #### GitHub Workflows
 
-1. **sync-aur.yml** (Every 6 hours): Syncs AUR packages according to `.omarchy/package.json` and opens a PR when changes are found.
+1. **sync-aur.yml** (Hourly): Syncs AUR packages according to `.omarchy/package.json` and opens a PR when changes are found.
 
 #### Systemd Services
 
-1. **check-versions** (Every 6 hours at :30): Pulls latest from git, compares PKGBUILD versions to published versions, creates state files if builds are needed
-2. **auto-release-edge** (Every 6 hours at +1:00): If state file exists, builds all edge packages that need updates
-3. **auto-release-stable** (Every 6 hours at +1:00): If state file exists, builds `release_ring=fast` packages for stable (runs in parallel with edge)
+1. **check-versions** (Hourly at :30): Pulls latest from git, compares PKGBUILD versions to published versions, creates state files if builds are needed
+2. **auto-release-edge** (Hourly at :00): If state file exists, builds all edge packages that need updates
+3. **auto-release-stable** (Hourly at :00): If state file exists, builds `release_ring=fast` packages for stable (runs in parallel with edge)
 
 State files are stored in `/root/.state/`:
 - `.sync-needed-edge`
@@ -401,8 +401,8 @@ State files are stored in `/root/.state/`:
 
 | Time | Action |
 |------|--------|
-| 00:30, 06:30, 12:30, 18:30 | check-versions (git pull + creates state files) |
-| 01:00, 07:00, 13:00, 19:00 | auto-release-edge + auto-release-stable (parallel) |
+| Every hour at :30 | check-versions (git pull + creates state files) |
+| Every hour at :00 | auto-release-edge + auto-release-stable (parallel) |
 
 ### Installation
 

--- a/systemd/omarchy-auto-release-edge.timer
+++ b/systemd/omarchy-auto-release-edge.timer
@@ -1,9 +1,9 @@
 [Unit]
-Description=Auto-release edge mirror every 6 hours
+Description=Auto-release edge mirror every hour
 
 [Timer]
-# Run every 6 hours at :00 (after version check at :30)
-OnCalendar=*-*-* 01,07,13,19:00:00 America/New_York
+# Run hourly at :00 (after version check at :30)
+OnCalendar=*-*-* *:00:00 America/New_York
 Persistent=true
 
 [Install]

--- a/systemd/omarchy-auto-release-stable.timer
+++ b/systemd/omarchy-auto-release-stable.timer
@@ -1,9 +1,9 @@
 [Unit]
-Description=Auto-release stable mirror every 6 hours
+Description=Auto-release stable mirror every hour
 
 [Timer]
-# Run every 6 hours at :00 (after version check at :30)
-OnCalendar=*-*-* 01,07,13,19:00:00 America/New_York
+# Run hourly at :00 (after version check at :30)
+OnCalendar=*-*-* *:00:00 America/New_York
 Persistent=true
 
 [Install]

--- a/systemd/omarchy-check-versions.timer
+++ b/systemd/omarchy-check-versions.timer
@@ -1,9 +1,9 @@
 [Unit]
-Description=Check package versions every 6 hours
+Description=Check package versions every hour
 
 [Timer]
-# Run every 6 hours at :30 (after GitHub sync at :00)
-OnCalendar=*-*-* 00,06,12,18:30:00 America/New_York
+# Run hourly at :30 (after GitHub sync at :00)
+OnCalendar=*-*-* *:30:00 America/New_York
 Persistent=true
 
 [Install]


### PR DESCRIPTION
## Why

The current six-hour AUR sync, version check, and release timers create separate waiting windows. An upstream fix can already be available, or its sync PR can already be merged, while edge and eligible stable packages continue serving the previous broken build until the next six-hour cycle.

The schedules are also unintentionally misaligned: GitHub cron runs in UTC, while the systemd timers use America/New_York. The documented :00 → :30 sequence is therefore several hours apart instead of 30 minutes apart. That extends the delta where a broken package can remain in stable after its upstream fix exists.

## Change

- Poll AUR package updates hourly.
- Check merged PKGBUILD versions hourly at :30.
- Run no-op-unless-needed edge and stable releases hourly at :00.
- Update the schedule documentation.

This preserves the existing review gate and stable release-ring policy. It only reduces the automated delay around them.