### PR TITLE
Install the fcitx5 input method unit

### DIFF
--- a/pkgbuilds/omarchy-settings-dev/PKGBUILD
+++ b/pkgbuilds/omarchy-settings-dev/PKGBUILD
@@ -165,6 +165,7 @@ package() {
   # migrations. Droppable once installs have run migration 1785095882.
   ln -sfn omarchy-migrate-notify.service "$pkgdir/usr/lib/systemd/user/omarchy-update-user-notify.service"
   install -Dm644 default/systemd/user/omarchy-tailscale-receive.service "$pkgdir/usr/lib/systemd/user/omarchy-tailscale-receive.service"
+  install -Dm644 default/systemd/user/omarchy-fcitx5.service "$pkgdir/usr/lib/systemd/user/omarchy-fcitx5.service"
   install -Dm644 default/systemd/zram-generator.conf.d/90-omarchy.conf "$pkgdir/usr/lib/systemd/zram-generator.conf.d/90-omarchy.conf"
 
   # Same for applications/** — used by omarchy-refresh-applications,


### PR DESCRIPTION
Companion to basecamp/omarchy#6398.

omarchy moves fcitx5 off Hyprland's fire-and-forget autostart onto a supervised systemd user service (`Restart=always`), so `~/.XCompose` compose sequences — `CapsLock` + `m` + `s` for an emoji — stop dying silently when the input method goes away. Ship the unit.

`test/shell.d/config-test.sh` in omarchy asserts the PKGBUILD explicitly installs every shipped user unit, so that test fails until this lands.
