### PR TITLE
Mark tobi-try arch=any

### DIFF
--- a/pkgbuilds/tobi-try/PKGBUILD
+++ b/pkgbuilds/tobi-try/PKGBUILD
@@ -3,10 +3,10 @@
 pkgname='tobi-try'
 pkgver=1.8.1
 _subver=d1bc484cc31a34db3d287550f4800e9a6e56bacd
-pkgrel=2
+pkgrel=3
 pkgdesc='Fresh directories for every vibe.'
 url='https://github.com/tobi/try'
-arch=('aarch64' 'x86_64')
+arch=('any')
 license=('MIT')
 depends=('ruby')
 provides=('try')


### PR DESCRIPTION
`tobi-try` contains no architecture-dependent content. The whole payload is three Ruby files plus a symlink:

```
usr/bin/try -> /usr/lib/tobi-try/try.rb
usr/lib/tobi-try/try.rb
usr/lib/tobi-try/lib/tui.rb
usr/lib/tobi-try/lib/fuzzy.rb
```

`build()` only rewrites the shebang to `/usr/bin/ruby`, `package()` only installs those files, and there are no `makedepends`. Declaring `arch=('aarch64' 'x86_64')` means makepkg stamps whichever machine built it, so serving both architectures requires two separate builds of a byte-identical payload. `arch=('any')` makes one build cover every architecture.

Verified rather than assumed: I built this on aarch64 and compared the result against the published `tobi-try-1.8.1-2-x86_64` from `edge`. The file lists match, the payloads are byte-identical under `diff -r --no-dereference`, and the `/usr/bin/try` symlink target is the same. The new package reports `arch = any`.

Practical effect: `edge/aarch64` and `stable/aarch64` currently 404, so ARM users get nothing from this package today. Because `any` packages are architecture-independent, this one change makes `tobi-try` installable on aarch64 straight from the existing `x86_64` repo path — no aarch64 publishing pipeline needed for it.

I bumped `pkgrel` to 3 so the rebuild is picked up.

Context: I hit this while working on the Apple Silicon / Asahi fork of Omarchy, where `tobi-try` shows up as unavailable. Happy to look at the other script-only packages in the same position if this direction is useful — I didn't want to widen the diff unprompted.
