### PR TITLE
Add ttfx — terminal text effects as a single static binary

### DIFF
--- a/pkgbuilds/ttfx/.omarchy/package.json
+++ b/pkgbuilds/ttfx/.omarchy/package.json
@@ -1,0 +1,3 @@
+{
+  "source": "local"
+}

--- a/pkgbuilds/ttfx/PKGBUILD
+++ b/pkgbuilds/ttfx/PKGBUILD
@@ -1,0 +1,53 @@
+# Maintainer: David Heinemeier Hansson <david@hey.com>
+
+pkgname=ttfx
+pkgver=0.1.0
+pkgrel=1
+pkgdesc="Terminal text effects as a single static binary — Rust port of terminaltexteffects"
+arch=('x86_64' 'aarch64')
+url="https://github.com/omacom-io/termfx"
+license=('MIT')
+depends=('gcc-libs' 'glibc')
+makedepends=('cargo')
+options=('!debug')
+
+# The repo is omacom-io/termfx; the binary it ships is `ttfx`.
+_srcname=termfx
+source=("$pkgname-$pkgver.tar.gz::$url/archive/refs/tags/v$pkgver.tar.gz")
+sha256sums=('d5aa53227fd79b4bc4031c521c042daf64d592dd55ddc772cdaaaca62e30464a')
+
+prepare() {
+  cd "$_srcname-$pkgver"
+
+  cargo fetch --locked --target "$CARCH-unknown-linux-gnu"
+}
+
+build() {
+  cd "$_srcname-$pkgver"
+
+  export CARGO_TARGET_DIR=target
+  cargo build --frozen --release
+}
+
+check() {
+  cd "$_srcname-$pkgver"
+
+  # Engine goldens and state-machine traces only. The frame-parity suites are
+  # deliberately skipped here: they need python3 plus a network clone of the
+  # pinned upstream reference, which doesn't belong in a package build.
+  export CARGO_TARGET_DIR=target
+  cargo test --frozen --release
+}
+
+package() {
+  cd "$_srcname-$pkgver"
+
+  install -Dm755 "target/release/ttfx" "$pkgdir/usr/bin/ttfx"
+  install -Dm644 LICENSE "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+  install -Dm644 README.md "$pkgdir/usr/share/doc/$pkgname/README.md"
+
+  "target/release/ttfx" --print-completion bash |
+    install -Dm644 /dev/stdin "$pkgdir/usr/share/bash-completion/completions/ttfx"
+  "target/release/ttfx" --print-completion zsh |
+    install -Dm644 /dev/stdin "$pkgdir/usr/share/zsh/site-functions/_ttfx"
+}

--- a/pkgbuilds/ttfx/PKGBUILD
+++ b/pkgbuilds/ttfx/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: David Heinemeier Hansson <david@hey.com>
 
 pkgname=ttfx
-pkgver=0.1.1
+pkgver=0.1.2
 pkgrel=1
 pkgdesc="Terminal text effects as a single static binary — Rust port of terminaltexteffects"
 arch=('x86_64' 'aarch64')
@@ -12,7 +12,7 @@ makedepends=('cargo')
 options=('!debug')
 
 source=("$pkgname-$pkgver.tar.gz::$url/archive/refs/tags/v$pkgver.tar.gz")
-sha256sums=('1b6c991427054a56ebf26c9fc5bc88f53e69382d0f6cb6788fcdb6304b763c07')
+sha256sums=('1c07268892e79c9e85bc09218ac5c5c81095a0df2d926eb4d5b257f18f7cf037')
 
 prepare() {
   cd "$pkgname-$pkgver"

--- a/pkgbuilds/ttfx/PKGBUILD
+++ b/pkgbuilds/ttfx/PKGBUILD
@@ -1,36 +1,34 @@
 # Maintainer: David Heinemeier Hansson <david@hey.com>
 
 pkgname=ttfx
-pkgver=0.1.0
+pkgver=0.1.1
 pkgrel=1
 pkgdesc="Terminal text effects as a single static binary — Rust port of terminaltexteffects"
 arch=('x86_64' 'aarch64')
-url="https://github.com/omacom-io/termfx"
+url="https://github.com/omacom-io/ttfx"
 license=('MIT')
 depends=('gcc-libs' 'glibc')
 makedepends=('cargo')
 options=('!debug')
 
-# The repo is omacom-io/termfx; the binary it ships is `ttfx`.
-_srcname=termfx
 source=("$pkgname-$pkgver.tar.gz::$url/archive/refs/tags/v$pkgver.tar.gz")
-sha256sums=('d5aa53227fd79b4bc4031c521c042daf64d592dd55ddc772cdaaaca62e30464a')
+sha256sums=('1b6c991427054a56ebf26c9fc5bc88f53e69382d0f6cb6788fcdb6304b763c07')
 
 prepare() {
-  cd "$_srcname-$pkgver"
+  cd "$pkgname-$pkgver"
 
   cargo fetch --locked --target "$CARCH-unknown-linux-gnu"
 }
 
 build() {
-  cd "$_srcname-$pkgver"
+  cd "$pkgname-$pkgver"
 
   export CARGO_TARGET_DIR=target
   cargo build --frozen --release
 }
 
 check() {
-  cd "$_srcname-$pkgver"
+  cd "$pkgname-$pkgver"
 
   # Engine goldens and state-machine traces only. The frame-parity suites are
   # deliberately skipped here: they need python3 plus a network clone of the
@@ -40,10 +38,11 @@ check() {
 }
 
 package() {
-  cd "$_srcname-$pkgver"
+  cd "$pkgname-$pkgver"
 
   install -Dm755 "target/release/ttfx" "$pkgdir/usr/bin/ttfx"
   install -Dm644 LICENSE "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+  install -Dm644 NOTICE "$pkgdir/usr/share/licenses/$pkgname/NOTICE"
   install -Dm644 README.md "$pkgdir/usr/share/doc/$pkgname/README.md"
 
   "target/release/ttfx" --print-completion bash |


### PR DESCRIPTION
Adds `ttfx`, a Rust port of [terminaltexteffects](https://github.com/ChrisBuilds/terminaltexteffects) that renders **byte-identical frames** to the Python original while shipping as one dependency-free binary.

Source: [omacom-io/ttfx](https://github.com/omacom-io/ttfx) · [v0.1.0](https://github.com/omacom-io/ttfx/releases/tag/v0.1.0)

### Why

Omarchy currently pulls `python-terminaltexteffects` for the screensaver and the first-boot provisioning animation. That means a Python interpreter on the base image, and ~107 ms of import before the first frame.

The screensaver runs at `--frame-rate 120` with `--random-effect`. On a fullscreen canvas the heavier effects cannot hold that in Python:

| At 200×50 cells | ttfx | Python TTE |
|---|---|---|
| beams | 564 fps | **71 fps** |
| slide | 5,113 fps | 264 fps |
| waves | 4,118 fps | 491 fps |
| startup | 1.2 ms | 107 ms |

120 fps needs ≤ 8.33 ms/frame; Python beams takes 14.1 ms, so whenever the screensaver rolls a heavy effect it drops frames today.

### Fidelity

Not a lookalike — a parity port, verified mechanically against upstream v0.15.0 in CI: 354 frame-parity cases (byte-for-byte across configs and seeds), 41 full tty byte-stream cases, 19 CLI contract checks. All 37 effects, same option names and defaults, same exit codes.

Credit for every effect and the engine design belongs to ChrisBuilds; MIT licensed with the original copyright preserved.

### Verification

Built locally with `makepkg` on x86_64: `cargo test` passes in `check()`, the package installs the binary plus bash/zsh completions, and the packaged binary runs. `check()` deliberately skips the frame-parity suites since they need python3 and a network clone of the pinned reference.

A follow-up PR on omarchy swaps the screensaver and provisioning scripts over.

— 🤖 Claude, posting on behalf of @dhh
