### PR TITLE
Add omasnap screenshot editor

### DIFF
--- a/pkgbuilds/omasnap/.omarchy/package.json
+++ b/pkgbuilds/omasnap/.omarchy/package.json
@@ -1,0 +1,3 @@
+{
+  "source": "local"
+}

--- a/pkgbuilds/omasnap/PKGBUILD
+++ b/pkgbuilds/omasnap/PKGBUILD
@@ -1,0 +1,48 @@
+# Maintainer: Tobi Lütke <tobi@lutke.com>
+
+pkgname=omasnap
+pkgver=1.0.3
+pkgrel=1
+pkgdesc="Native Wayland screenshot and annotation overlay for Hyprland"
+arch=('x86_64')
+url="https://github.com/tobi/omasnap"
+license=('custom')
+depends=(
+  'grim'
+  'hyprland'
+  'hyprpicker'
+  'layer-shell-qt'
+  'qt6-base'
+  'tesseract'
+  'tesseract-data-eng'
+  'wayland'
+  'wl-clipboard'
+)
+makedepends=(
+  'cmake'
+  'ninja'
+  'pkgconf'
+  'wayland-protocols'
+)
+options=('!debug')
+
+source=("$pkgname-$pkgver.tar.gz::$url/archive/refs/tags/v$pkgver.tar.gz")
+sha256sums=('6dd8568b4ea3ab4221ca1be36149c8be3e9c3d7f1bc1143b79caff760e6a7cfd')
+
+build() {
+  cmake -S "$pkgname-$pkgver" -B build -G Ninja \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_INSTALL_PREFIX=/usr
+  cmake --build build --parallel
+}
+
+check() {
+  QT_QPA_PLATFORM=offscreen \
+    ./build/omasnap-smoke "$srcdir/omasnap-smoke-output"
+}
+
+package() {
+  cmake --install build --prefix "$pkgdir/usr"
+  install -Dm644 "$pkgname-$pkgver/README.md" \
+    "$pkgdir/usr/share/doc/$pkgname/README.md"
+}


### PR DESCRIPTION
Adds `omasnap`, a native Wayland screenshot and annotation overlay for Hyprland and Omarchy.

Source: [tobi/omasnap](https://github.com/tobi/omasnap) · [v1.0.5](https://github.com/tobi/omasnap/releases/tag/v1.0.5)

![Looping Omasnap demonstration](https://raw.githubusercontent.com/tobi/omasnap/main/assets/omasnap.gif)

### What it does

- Region, window, and full-monitor capture.
- Wayland layer-shell editor with movable/resizable vector annotations.
- Arrows, lines, freehand strokes, rectangles, numbered markers, and text.
- OCR-region capture, mesh-gradient backdrops, and rendered drop shadows.
- PNG clipboard output through `wl-copy` and timestamped files under `~/Pictures/Screenshots`.
- Native-pixel output on scaled monitors; clean window-surface capture uses Hyprland's `ext-image-copy-capture-v1` protocols when available.

### Package

Builds the tagged source with CMake/Ninja, runs the offscreen interaction smoke in `check()`, and installs `/usr/bin/omasnap`, the desktop entry, documentation, and the bundled Neucha OFL license. Runtime dependencies cover Hyprland discovery, `grim`/`hyprpicker` capture, layer-shell/Qt rendering, clipboard persistence, and English OCR data.

The package is `x86_64` for this submission, matching the `linux-ptl` target; aarch64 can be enabled after an ARM build is validated.

### Verification

- `makepkg -f` passed on x86_64, including `check()`.
- The built package reports `omasnap 1.0.3` and contains only the expected binary, desktop entry, README, and font license.
- `bin/repo list --json` recognizes the local package, and `bin/repo build --package omasnap --dry-run` schedules it for edge.
- A live Hyprland shortcut mapped the layer as namespace `omasnap` and closed cleanly.

— 🤖 Claude, posting on behalf of @tobi