### PR TITLE
Update omasnap to 1.0.6

### DIFF
--- a/pkgbuilds/omasnap/PKGBUILD
+++ b/pkgbuilds/omasnap/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Tobi Lütke <tobi@lutke.com>
 
 pkgname=omasnap
-pkgver=1.0.5
+pkgver=1.0.6
 pkgrel=1
 pkgdesc="Native Wayland screenshot and annotation overlay for Hyprland"
 arch=('x86_64')
@@ -10,7 +10,6 @@ license=('custom')
 depends=(
   'grim'
   'hyprland'
-  'hyprpicker'
   'layer-shell-qt'
   'qt6-base'
   'tesseract'
@@ -27,7 +26,7 @@ makedepends=(
 options=('!debug')
 
 source=("$pkgname-$pkgver.tar.gz::$url/archive/refs/tags/v$pkgver.tar.gz")
-sha256sums=('4581a02af12e48f49468dbb944ec6040f7d9c04f6170960fb6198bc79f841be8')
+sha256sums=('7d25d6e2bcb4ddc1541382655fa2245980829c0f51a8d720b3e63fbee8142474')
 
 build() {
   cmake -S "$pkgname-$pkgver" -B build -G Ninja \

--- a/pkgbuilds/omasnap/PKGBUILD
+++ b/pkgbuilds/omasnap/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Tobi Lütke <tobi@lutke.com>
 
 pkgname=omasnap
-pkgver=1.0.3
+pkgver=1.0.5
 pkgrel=1
 pkgdesc="Native Wayland screenshot and annotation overlay for Hyprland"
 arch=('x86_64')
@@ -27,7 +27,7 @@ makedepends=(
 options=('!debug')
 
 source=("$pkgname-$pkgver.tar.gz::$url/archive/refs/tags/v$pkgver.tar.gz")
-sha256sums=('6dd8568b4ea3ab4221ca1be36149c8be3e9c3d7f1bc1143b79caff760e6a7cfd')
+sha256sums=('4581a02af12e48f49468dbb944ec6040f7d9c04f6170960fb6198bc79f841be8')
 
 build() {
   cmake -S "$pkgname-$pkgver" -B build -G Ninja \


### PR DESCRIPTION
Updates `omasnap` from 1.0.3 to 1.0.6.

Release: https://github.com/tobi/omasnap/releases/tag/v1.0.6

Highlights:
- Persistent `/tmp/omasnap/snapshot-<pid>.png` working images after selection and every edit.
- Clean native Wayland window capture with no desktop-crop fallback.
- Clipboard output is verified after `wl-copy`, retried once on failure, and remains available after Omasnap exits.
- Screenshot notifications include a thumbnail and open the image through `xdg-open` when clicked.
- Undo/redo history and endpoint-only arrow/line selection fixes.

Verification: upstream Arch Linux CI build and interaction smoke passed; local clean `makepkg -C -f` passed.