### PR TITLE
Update omatrack to 0.9.10

### DIFF
--- a/pkgbuilds/omatrack/PKGBUILD
+++ b/pkgbuilds/omatrack/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: David Heinemeier Hansson <david@hey.com>
 
 pkgname=omatrack
-pkgver=0.9.0
+pkgver=0.9.10
 pkgrel=1
 pkgdesc="Cross-format motorsport telemetry analysis workstation"
 arch=('x86_64' 'aarch64')
@@ -11,9 +11,9 @@ depends=('qt6-base' 'qt6-declarative' 'mpv' 'libyaml' 'gcc-libs' 'glibc' 'hicolo
 makedepends=('cmake' 'ninja' 'rust')
 options=('!debug' '!lto')
 
-_commit=8ade6b45de53a59e45cb46777c50422d31bde86f
+_commit=addfb3d4de6e6a39d4f5113d6930875fd97ec377
 source=("omatrack-$_commit.tar.gz::$url/archive/$_commit.tar.gz")
-sha256sums=('f295a1aa7c3cd7b2eba1650db10e59ac722b5d69e49db3e0d40ad6bbac538191')
+sha256sums=('f9218ccd5fc513a61a0590b89c4180bc9e027173470f947a201fa5ab85d7d1f0')
 
 prepare() {
   cd "omatrack-$_commit/third_party/motorsport-telemetry"


### PR DESCRIPTION
## Summary

Updates Omatrack from 0.9.0 to 0.9.10, pinned to the signed `v0.9.10` release commit (`addfb3d4de6e6a39d4f5113d6930875fd97ec377`).

## Changelog

### Telemetry analysis and trace workspace

- Replaced the CPU trace path with a batched Qt Quick scene-graph renderer, including pixel-bounded min/max envelopes and cached text geometry.
- Added in-place corner inspection with brake, turn-in, apex, and throttle-pickup guides.
- Added multi-lap brake-point consistency for the fastest representative session laps.
- Added a fastest-half session-confidence mode with median traces, 10th–90th percentile bands, and variance heatmaps.
- Added a discoverable toolbar toggle for persistent confidence display while retaining hold-to-preview.
- Prevented trace hover from seeking telemetry video; clicks and drags still move the playhead.
- Moved trace controls above the corner labels to keep both interaction surfaces clear.

### Video

- Stabilized simultaneous primary/reference video startup and render-thread teardown.
- Preserved primary/reference ordering during explicit dual-video selection.
- Improved paused dual-video alignment and continuous playback synchronization without periodic hard seeks.
- Reduced the fullscreen telemetry HUD by 35%, preserved its aspect ratio, centered it horizontally, and fixed it within the lower 20% of the video.

### Library, ingestion, and memory

- Unified local folders and WebDAV connections into one ordered location model.
- Added authenticated WebDAV caching with offline fallback.
- Added drag/drop, file-dialog, command-line, and recent-file opening for telemetry and video.
- Kept session metadata lazy, shared QML menu/cache data, freed raw channel arrays after unification, and bounded unified-lap caches across session switches.

### Packaging and CI

- Added hardened portable release bundles and flat Windows release zips.
- Corrected AppImage dependency audits and Linux loader-library preservation.
- Improved Windows test failure visibility in CI.

## Package changes

- `pkgver`: `0.9.0` → `0.9.10`
- `_commit`: `8ade6b45…` → `addfb3d4…`
- Updated the SHA-256 checksum for the pinned GitHub source archive.

## Validation

- Upstream Omatrack [CI run](https://github.com/tobi/omatrack/actions/runs/31449294211): passed.
- Upstream Omatrack [release run](https://github.com/tobi/omatrack/actions/runs/31449295384): passed.
- `bash -n PKGBUILD`: passed.
- `makepkg --verifysource`: checksum passed.
- `bin/repo release --package omatrack --dry-run`: selected `omatrack 0.9.10-1` for edge.
- `bin/repo build --package omatrack`: built `omatrack-0.9.10-1-x86_64.pkg.tar.zst` successfully in a clean Docker environment.
- Extracted the package and ran its `omatrack-cli` against a real eight-lap Cosworth PDS session: 31 channels mapped, eight laps detected, `parse: OK`.
- aarch64 QEMU validation resolved all dependencies and reached Omatrack compilation after refreshing the binfmt handler with credential-preserving flags; the emulated build exceeded the one-hour execution cap before completion.