### PR TITLE
Update omasnap to 1.12.0

### DIFF
--- a/pkgbuilds/omasnap/PKGBUILD
+++ b/pkgbuilds/omasnap/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Tobi Lütke <tobi@lutke.com>
 
 pkgname=omasnap
-pkgver=1.11.0
+pkgver=1.12.0
 pkgrel=1
 pkgdesc="Native Wayland screenshot and annotation overlay for Hyprland"
 arch=('x86_64')
@@ -26,7 +26,7 @@ makedepends=(
 options=('!debug')
 
 source=("$pkgname-$pkgver.tar.gz::$url/archive/refs/tags/v$pkgver.tar.gz")
-sha256sums=('ec9af2b840d7d72401cc6921716497b0c8a2cd27763d43a7b23ed71c6c0be84a')
+sha256sums=('cf09929e104fe29783ec93157120972e751481daed6dcd7272875c109b7f7312')
 
 build() {
   cmake -S "$pkgname-$pkgver" -B build -G Ninja \

--- a/pkgbuilds/omasnap/PKGBUILD
+++ b/pkgbuilds/omasnap/PKGBUILD
@@ -1,12 +1,12 @@
 # Maintainer: Tobi Lütke <tobi@lutke.com>
 
 pkgname=omasnap
-pkgver=1.10.0
+pkgver=1.11.0
 pkgrel=1
 pkgdesc="Native Wayland screenshot and annotation overlay for Hyprland"
 arch=('x86_64')
 url="https://github.com/tobi/omasnap"
-license=('custom')
+license=('MIT')
 depends=(
   'grim'
   'hyprland'
@@ -26,7 +26,7 @@ makedepends=(
 options=('!debug')
 
 source=("$pkgname-$pkgver.tar.gz::$url/archive/refs/tags/v$pkgver.tar.gz")
-sha256sums=('6d965291043bcd9bdce541f4bc51776a6d3609d0c64b27b5f9ae47caa820acf9')
+sha256sums=('ec9af2b840d7d72401cc6921716497b0c8a2cd27763d43a7b23ed71c6c0be84a')
 
 build() {
   cmake -S "$pkgname-$pkgver" -B build -G Ninja \

--- a/pkgbuilds/omasnap/PKGBUILD
+++ b/pkgbuilds/omasnap/PKGBUILD
@@ -44,4 +44,6 @@ package() {
   cmake --install build --prefix "$pkgdir/usr"
   install -Dm644 "$pkgname-$pkgver/README.md" \
     "$pkgdir/usr/share/doc/$pkgname/README.md"
+  install -Dm644 "$pkgname-$pkgver/LICENSE" \
+    "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
 }


### PR DESCRIPTION
## Summary
- update omasnap from 1.10.0 to 1.12.0
- refresh the GitHub release tarball checksum
- mark the package MIT and install LICENSE

## Verification
- source tarball checksum verified against v1.12.0
- GitHub release https://github.com/tobi/omasnap/releases/tag/v1.12.0 is published
- omasnap 1.12.0 headless smoke test passed