### PR TITLE
Install omarchy-crash-watch.service into /usr/lib/systemd/user

### DIFF
--- a/pkgbuilds/omarchy-settings/PKGBUILD
+++ b/pkgbuilds/omarchy-settings/PKGBUILD
@@ -164,6 +164,7 @@ package() {
   ln -sfn omarchy-migrate-notify.service "$pkgdir/usr/lib/systemd/user/omarchy-update-user-notify.service"
   install -Dm644 default/systemd/user/omarchy-tailscale-receive.service "$pkgdir/usr/lib/systemd/user/omarchy-tailscale-receive.service"
   install -Dm644 default/systemd/user/omarchy-fcitx5.service "$pkgdir/usr/lib/systemd/user/omarchy-fcitx5.service"
+  install -Dm644 default/systemd/user/omarchy-crash-watch.service "$pkgdir/usr/lib/systemd/user/omarchy-crash-watch.service"
   # Marks app.slice (and only app.slice) as a systemd-oomd kill candidate, so
   # memory pressure costs one app scope instead of the compositor session.
   # Thresholds live in etc/systemd/oomd.conf.d/10-omarchy.conf.


### PR DESCRIPTION
`omarchy/#6746` added `omarchy-crash-watch` — the binary, the unit, the `enable-user-units.sh` entry, a migration, and a test asserting this install — but the matching install line here never landed. So `omarchy-settings` shipped the unit only into the `/usr/share/omarchy/default/systemd/user/` template tree and never into `/usr/lib/systemd/user/`, where systemd looks.

Every other user unit is installed to both. This adds the missing line.

## Impact

`install/user/first-run/enable-user-units.sh` enables its six units in one `systemctl --user enable --now` call, so the missing unit failed the whole call:

```
Failed to enable unit: Unit omarchy-crash-watch.service does not exist
```

`omarchy-provision-first-run` only marks `first-run-user` when every step succeeds, so three things followed:

1. **First-run never completed** and replayed the full sequence on every login, re-firing the "Learn Keybindings" and "Update System" notifications each boot.
2. **`enable` is atomic**, so the other five units were never enabled either — no Bluetooth pairing agent, sleep lock, monitor recovery, migrate notifier, or fcitx5.
3. **Migration `1786539345`** falls back to writing the wants symlink by hand when there's no live user manager. It points at the `/usr/lib` path this omission left empty, so existing installs that ran it got a dangling symlink.

## No migration needed

Affected installs retry first-run on the next login and now succeed, and the dangling symlinks resolve the moment the file exists at that path.

## Verification

`test/shell.d/config-test.sh` already asserts this install. Before:

```
PKGBUILD does not explicitly install default/systemd/user/omarchy-crash-watch.service -> /usr/lib/systemd/user/omarchy-crash-watch.service
TEST_EXIT=1
```

After, the suite passes clean. Also confirmed on a live 4.0.0rc1-1 install: linking the unit and re-running first-run marks `first-run-user`, brings all six units up, and stops the repeating notifications.

🤖 Generated with [Claude Code](https://claude.com/claude-code)