### PR TITLE
Serialize repository commands with an flock mutex

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ pkgbuilds/symfony-cli/symfony*
 pkgbuilds/yay/yay/
 .srcdest/
 .repo-host
+.repo.lock

--- a/bin/build
+++ b/bin/build
@@ -97,6 +97,11 @@ if [[ "$DRY_RUN" == true ]]; then
   exit $?
 fi
 
+# Past the dry run everything below mutates shared state: the workspace is wiped
+# a few lines down, and src/ is shared across mirrors. A no-op when bin/repo or
+# bin/release already holds the lock.
+acquire_repo_lock "build --mirror $MIRROR --arch $ARCH"
+
 # Create directories if they don't exist
 mkdir -p "$BUILD_OUTPUT_DIR" "$REPO_DIR" "$SRC_DIR"
 

--- a/bin/deploy
+++ b/bin/deploy
@@ -94,6 +94,11 @@ if [[ "$PACKAGE_FLAG_GIVEN" == true && ${#PACKAGES[@]} -eq 0 ]]; then
   exit 1
 fi
 
+# Guards this machine's build workspace for the whole build-then-push run. The
+# repository host runs its own lock; see the note in bin/push-build about the
+# window this does not cover.
+[[ "$DRY_RUN" == true ]] || acquire_repo_lock "deploy --mirror $MIRROR --arch $ARCH"
+
 # bin/build asks the local repository database what is already built. On a build
 # machine that database does not exist, so every package looks unbuilt and an
 # unscoped run rebuilds the entire repository and publishes it. Deploying from

--- a/bin/promote-build
+++ b/bin/promote-build
@@ -46,6 +46,10 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
+# Moving artifacts into the published repository is the least reversible step in
+# the pipeline. A dry run only lists them, so it stays lock-free.
+[[ "$DRY_RUN" == true ]] || acquire_repo_lock "promote --mirror $MIRROR --arch $ARCH"
+
 print_info "Mirror: $MIRROR"
 print_info "Build output: $BUILD_OUTPUT_DIR"
 print_info "Final output: $REPO_DIR"

--- a/bin/push-build
+++ b/bin/push-build
@@ -275,6 +275,13 @@ print_success "Host ready"
 echo ""
 
 print_info "Uploading packages..."
+# Known gap: this writes into the host's shared build-output/ before the host's
+# lock is taken (bin/upload-prebuilt acquires it further down), so a release
+# starting mid-transfer can wipe or prematurely publish what is landing here.
+# Holding a remote lock across the transfer needs an ssh session that outlives
+# the rsync, which is its own change. The checksum verification below catches
+# the destructive half of that race before anything is published.
+#
 # Prefix with ./ so rsync does not read an epoch's colon (spotify-1:1.2.3-...)
 # as a host:path separator.
 rsync_sources=()

--- a/bin/release
+++ b/bin/release
@@ -85,6 +85,11 @@ print_info "Target architecture: $ARCH"
 print_info "Mirror: $MIRROR"
 print_info "Build workspace: $BUILD_OUTPUT_DIR"
 
+# One lock for all six steps. Taking it per step would leave gaps where another
+# run could build against a half-published repository — which is how two
+# releases 42 seconds apart both rebuilt omarchy 4.0.0rc2.
+[[ "$DRY_RUN" == true ]] || acquire_repo_lock "release --mirror $MIRROR --arch $ARCH"
+
 # Step 1: Build
 echo ""
 if [[ "$DRY_RUN" == true ]]; then

--- a/bin/repo
+++ b/bin/repo
@@ -22,27 +22,6 @@ for ((i=1; i<=$#; i++)); do
   fi
 done
 
-# Setup logging with timestamps
-mkdir -p "$LOG_DIR"
-
-# Rotate logs first - keep only the 10 most recent
-if [[ -d "$LOG_DIR" ]]; then
-  cd "$LOG_DIR"
-  # List logs by modification time (newest first), skip first 9, delete the rest
-  # This way after we create the new log, we'll have exactly 10
-  ls -t repo_*.log 2>/dev/null | tail -n +10 | xargs -r rm -f
-  cd "$BUILD_ROOT"
-fi
-
-TIMESTAMP=$(date +%Y%m%d_%H%M%S)
-if [[ -n "$LOG_MIRROR" ]]; then
-  LOG_FILE="$LOG_DIR/repo_${LOG_MIRROR}_${TIMESTAMP}.log"
-else
-  LOG_FILE="$LOG_DIR/repo_${TIMESTAMP}.log"
-fi
-export LOG_FILE
-export OMARCHY_LOG_FILE="$LOG_FILE"
-
 # Show usage
 show_usage() {
   echo "Usage: $0 <command> [options]"
@@ -85,6 +64,35 @@ fi
 # Get command and shift arguments
 COMMAND="$1"
 shift
+
+# Reading metadata changes nothing; every other command touches the shared build
+# workspace or the published repository and must not overlap with another run.
+case $COMMAND in
+list | -h | --help | help) ;;
+*) acquire_repo_lock "repo $COMMAND" ;;
+esac
+
+# Setup logging with timestamps. Named after the lock is held so a run that
+# queued behind another one is logged under the time it actually started.
+mkdir -p "$LOG_DIR"
+
+# Rotate logs first - keep only the 10 most recent
+if [[ -d "$LOG_DIR" ]]; then
+  cd "$LOG_DIR"
+  # List logs by modification time (newest first), skip first 9, delete the rest
+  # This way after we create the new log, we'll have exactly 10
+  ls -t repo_*.log 2>/dev/null | tail -n +10 | xargs -r rm -f
+  cd "$BUILD_ROOT"
+fi
+
+TIMESTAMP=$(date +%Y%m%d_%H%M%S)
+if [[ -n "$LOG_MIRROR" ]]; then
+  LOG_FILE="$LOG_DIR/repo_${LOG_MIRROR}_${TIMESTAMP}.log"
+else
+  LOG_FILE="$LOG_DIR/repo_${TIMESTAMP}.log"
+fi
+export LOG_FILE
+export OMARCHY_LOG_FILE="$LOG_FILE"
 
 # Route to appropriate script with logging
 case $COMMAND in

--- a/bin/upload-prebuilt
+++ b/bin/upload-prebuilt
@@ -4,6 +4,10 @@
 set -e
 
 SCRIPT_DIR=$(realpath "${BASH_SOURCE[0]%/*}")
+BUILD_ROOT=$(realpath "$SCRIPT_DIR/..")
+
+source "$BUILD_ROOT/helpers/message-helpers.sh"
+source "$BUILD_ROOT/helpers/lock-helpers.sh"
 
 # Only sync understands the publishing flags; sign, promote and update reject
 # unknown options outright, so they cannot be forwarded blindly.
@@ -25,6 +29,10 @@ while [[ $# -gt 0 ]]; do
     ;;
   esac
 done
+
+# Hold one lock across all four steps. Letting bin/repo take and release its own
+# lock per step would leave gaps where a release could promote between them.
+acquire_repo_lock "upload-prebuilt"
 
 "$SCRIPT_DIR/repo" sign "${COMMON_ARGS[@]}"
 "$SCRIPT_DIR/repo" promote "${COMMON_ARGS[@]}"

--- a/helpers/lock-helpers.sh
+++ b/helpers/lock-helpers.sh
@@ -1,0 +1,72 @@
+# Serialize commands that mutate the build workspace or the published repository.
+#
+# bin/build wipes build-output/ at startup, bin/promote-build moves files into
+# pkgs.omarchy.org/, and every mirror shares src/ and .srcdest/. Two overlapping
+# runs therefore delete each other's artifacts mid-flight and can promote an
+# incomplete package set. On 2026-08-12 two edge releases started 42 seconds
+# apart; both read the repository database before the first had updated it, both
+# rebuilt omarchy 4.0.0rc2, and only promote-build's refusal to overwrite a
+# published file stopped the second from republishing what was already live.
+#
+# Wait rather than fail: a queued run re-reads the database once the holder has
+# updated it and correctly skips what was just published, and the edge and
+# stable auto-release timers are scheduled for the same minute by design.
+
+OMARCHY_PKGS_LOCK_TIMEOUT="${OMARCHY_PKGS_LOCK_TIMEOUT:-3600}"
+
+# True when this process already holds the lock through an ancestor: bin/repo
+# calls bin/build, bin/upload-prebuilt calls bin/repo four times, and those
+# nested calls must not deadlock waiting on their own parent.
+#
+# Confirming the inherited descriptor still points at the same file, rather than
+# trusting the exported path alone, keeps a stale or hand-set variable from
+# waving a run through unserialized. A descriptor that fails to check out falls
+# through to a real acquire, which blocks loudly instead of running unprotected.
+repo_lock_held() {
+  local lock_file="$1"
+
+  [[ "${OMARCHY_PKGS_LOCK_HELD:-}" == "$lock_file" ]] || return 1
+  [[ -n "${OMARCHY_PKGS_LOCK_FD:-}" ]] || return 1
+  [[ -e "/proc/self/fd/$OMARCHY_PKGS_LOCK_FD" ]] || return 1
+  [[ "/proc/self/fd/$OMARCHY_PKGS_LOCK_FD" -ef "$lock_file" ]]
+}
+
+acquire_repo_lock() {
+  local label="$1"
+  local lock_file="$BUILD_ROOT/.repo.lock"
+
+  repo_lock_held "$lock_file" && return 0
+
+  if ! command -v flock >/dev/null; then
+    print_error "flock not found (install util-linux); refusing to run unserialized"
+    exit 1
+  fi
+
+  # Append mode: opening with > would truncate the current holder's details
+  # before we get a chance to report them.
+  exec {OMARCHY_PKGS_LOCK_FD}>>"$lock_file"
+
+  if ! flock -n "$OMARCHY_PKGS_LOCK_FD"; then
+    local holder
+    holder=$(<"$lock_file")
+    print_warning "Another repository command is running: ${holder:-unknown}"
+    print_info "Waiting up to ${OMARCHY_PKGS_LOCK_TIMEOUT}s for it to finish..."
+
+    if ! flock -w "$OMARCHY_PKGS_LOCK_TIMEOUT" "$OMARCHY_PKGS_LOCK_FD"; then
+      print_error "Timed out after ${OMARCHY_PKGS_LOCK_TIMEOUT}s waiting for the repository lock"
+      print_warning "Holder: ${holder:-unknown}"
+      print_info "Lock file: $lock_file"
+      exit 1
+    fi
+
+    print_success "Lock acquired, continuing"
+  fi
+
+  printf 'pid=%s command=%s started=%s\n' "$$" "$label" "$(date -Is)" >"$lock_file"
+
+  # Both are exported so nested calls can find and verify the descriptor. The
+  # descriptor itself is inherited across exec, which is what makes the check
+  # in repo_lock_held meaningful.
+  export OMARCHY_PKGS_LOCK_HELD="$lock_file"
+  export OMARCHY_PKGS_LOCK_FD
+}

--- a/helpers/paths.sh
+++ b/helpers/paths.sh
@@ -1,6 +1,11 @@
 # Common path variables for Omarchy package build system
 # This file should be sourced after setting BUILD_ROOT
 
+# Every script that knows these paths is a script that can mutate them, so the
+# mutex travels with them. Sourcing only defines acquire_repo_lock; each entry
+# point decides when to call it.
+source "$BUILD_ROOT/helpers/lock-helpers.sh"
+
 # Default architecture and mirror
 ARCH=${ARCH:-x86_64}
 MIRROR=${MIRROR:-edge}


### PR DESCRIPTION
## What happened

Two edge releases started 42 seconds apart on 2026-08-12:

| time | log | outcome |
|---|---|---|
| 21:32:05 | `repo_edge_20260812_213205.log` | read DB (still `4.0.0rc1-1`) → built omarchy + omarchy-settings → promoted → DB updated → synced → completed |
| 21:32:47 | `repo_20260812_213247.log` | read the *same* stale DB → rebuilt both → `promote-build` refused to overwrite the published file |

Both logged `Update available: 4.0.0rc1-1 -> 4.0.0rc2-1`. The second run's rebuild of the same commit differed from the published artifact only in `builddate`/mtime metadata, which is why promotion aborted.

The wasted build is the mild part. `bin/build` wipes `build-output/` at startup, so the second run deleted the first run's artifacts while it was still promoting them — the first run found 2 packages to promote, the second found 1. A differently-timed overlap could promote an incomplete set, e.g. `omarchy` without the `omarchy-settings=${pkgver}` it hard-pins. `src/` and `.srcdest/` are shared across mirrors too.

Production came out correct — both rc2 packages verify, are in the DB, and are on the mirror — so this is prevention, not repair.

## The change

`helpers/lock-helpers.sh` adds `acquire_repo_lock`, an flock on `$BUILD_ROOT/.repo.lock` that records `pid=… command=… started=…` so a waiting run can say who it is waiting for.

It **waits rather than fails** (default 3600s, `OMARCHY_PKGS_LOCK_TIMEOUT` to override). A queued run re-reads the DB once the holder has updated it and then correctly reports "already up to date" instead of rebuilding. Fail-fast would also break the auto-release timers, which are both set to `01,07,13,19:00:00` — one of them would lose every firing.

Acquired by `bin/repo` (every subcommand except `list`/`help`), `bin/upload-prebuilt` (one lock spanning all four steps, so a release cannot slip in between them), and `bin/release`, `bin/deploy`, `bin/build`, `bin/promote-build` for direct invocation. Nested calls no-op, so the outermost entry point owns the lock for the whole run.

Re-entrancy verifies that the inherited descriptor still points at the same file rather than trusting the exported path, so a stale or hand-set `OMARCHY_PKGS_LOCK_HELD` cannot wave a run through unserialized; a descriptor that fails the check falls through to a real acquire, blocking loudly instead of running unprotected.

Logging setup in `bin/repo` moved after acquisition, so a queued run's log is named for when it actually started rather than when it queued. Dry runs and `--help` stay lock-free.

## Known gaps, not addressed here

Found by review; each is pre-existing and independent of this change:

1. **`bin/push-build` rsyncs into the host's shared `build-output/` before the host's lock is taken** (`upload-prebuilt` acquires it afterwards). Holding a remote lock across the transfer needs an ssh session outliving the rsync, which is its own change. Commented at the call site; the existing checksum verification catches the destructive half of the race before anything is published.
2. **`bin/auto-release` lost wakeup** — `check-versions` can touch the state file during a release, and it is deleted afterwards; starting an already-active systemd oneshot does not queue another run.
3. **`git pull` in `ExecStartPre` of `omarchy-check-versions.service`** can update PKGBUILDs mid-build.
4. **Self-deadlock if `--host` resolves to the same checkout** — `bin/repo push` holds the lock while the remote `upload-prebuilt` waits for it. Times out rather than hanging forever.

## Verified locally

Contention blocks and names the holder; re-entrant calls do not deadlock; a hand-set env var no longer bypasses the lock; the timeout path errors cleanly; `--help` on every locked script returns immediately while the lock is held; `set -e` does not trip on either branch.

— 🤖 Claude, posting on behalf of @dhh