### PR TITLE
Ship the aether plugin cache under the name Omarchy 4 asks for

### DIFF
--- a/pkgbuilds/omarchy-nvim/PKGBUILD
+++ b/pkgbuilds/omarchy-nvim/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Ryan Hughes <ryan@omarchy.org>
 pkgname=omarchy-nvim
-pkgver=2026.8.1
+pkgver=2026.8.13
 pkgrel=1
 pkgdesc="Pre-built LazyVim configuration with cached plugins"
 arch=('any')
@@ -61,9 +61,16 @@ slim_lazy_repos() {
     # is half the package -- ~70 MB of .git across the plugins. `git fetch`
     # into a shallow repo stays shallow and re-fetches tags, so :Lazy update
     # still works.
-    git -C "$dir" symbolic-ref -d refs/remotes/origin/HEAD 2>/dev/null || true
+    #
+    # Keep refs/remotes/origin/HEAD. It pins no objects (it is a symref, and
+    # stays readable after its target ref is gone), but lazy.nvim resolves the
+    # default branch through it for plugins parked on a detached HEAD by a
+    # version pin -- lazy.nvim, LazyVim and blink.cmp. Without it, get_branch()
+    # returns nil and every lockfile write asserts, so :Lazy install/update/sync
+    # dies with E5113 on a fresh install.
     git -C "$dir" for-each-ref --format='%(refname)' refs/remotes refs/tags |
       while IFS= read -r ref; do
+        [[ $ref == refs/remotes/origin/HEAD ]] && continue
         git -C "$dir" update-ref -d "$ref"
       done
     rm -f "$dir/.git/FETCH_HEAD" "$dir/.git/ORIG_HEAD"

--- a/pkgbuilds/omarchy-nvim/lua/plugins/all-themes.lua
+++ b/pkgbuilds/omarchy-nvim/lua/plugins/all-themes.lua
@@ -1,13 +1,27 @@
 return {
 	-- Load all theme plugins but don't apply them
 	-- This ensures all colorschemes are available for hot-reloading
+	--
+	-- Omarchy 4 generates most theme specs from default/themed/neovim.lua.tpl on
+	-- top of aether, so the single-theme plugins below (ethereal, vantablack,
+	-- white, monokai-pro, miasma) are only reached by Omarchy 3.8, which ships a
+	-- neovim.lua per theme. Keep them until 3.8 is out of support.
 	{
 		"ribru17/bamboo.nvim",
 		lazy = true,
 		priority = 1000,
 	},
+	-- Name and branch must match Omarchy 4's generated theme spec
+	-- (default/themed/neovim.lua.tpl). lazy merges specs by url and lets an
+	-- explicit name rename the merged plugin, so a bare "bjarneo/aether.nvim"
+	-- here builds the cache into lazy/aether.nvim while every aether-themed
+	-- Omarchy 4 install renames it to lazy/aether at runtime -- a directory the
+	-- package never shipped. That cost a network clone on first launch, and the
+	-- theme fell back to tokyonight until nvim was restarted.
 	{
 		"bjarneo/aether.nvim",
+		branch = "v3",
+		name = "aether",
 		lazy = true,
 		priority = 1000,
 	},


### PR DESCRIPTION
Picking one of Omarchy 4's aether-based themes on a fresh install left Neovim on tokyonight until you restarted it, and cloned a plugin over the network on first launch.

## The cache shipped under the wrong name

Omarchy 4 generates most theme specs from `default/themed/neovim.lua.tpl` on top of aether, pinned as `name = "aether", branch = "v3"`. lazy indexes specs by url and lets an explicit `name` rename the merged plugin (`lazy/core/meta.lua:77-112`), so the bare `"bjarneo/aether.nvim"` entry in `all-themes.lua` built the cache into `lazy/aether.nvim`, while every aether-themed install renamed that same plugin to `lazy/aether` at runtime — a directory the package never shipped.

Six stock Omarchy 4 themes route through the template (`ethereal`, `lupine`, `miasma`, `ristretto`, `vantablack`, `white`), plus `last-horizon`.

Naming the entry to match builds the cache into `lazy/aether` directly. There is still only one clone: Omarchy 3.8's `hackerman` theme depends on the bare `"bjarneo/aether.nvim"` url, which merges into the same plugin, so 3.8 keeps resolving offline exactly as before. The package stays 32 MB compressed / 75 MB installed.

## `:Lazy install/update/sync` died with E5113

Separate regression from 45ca871. The slimming pass deleted `refs/remotes/origin/HEAD`, but lazy.nvim resolves the default branch through it for plugins parked on a detached HEAD by a version pin — `lazy.nvim`, `LazyVim`, `blink.cmp`. Without it `get_branch()` returns nil and `lock.lua:28` asserts, so every lockfile write threw:

```
E5113: ...lazy/manage/lock.lua:28: assertion failed!
```

That fired on first launch alongside the aether clone above, and took out the obvious self-heal path with it. The symref pins no objects and stays readable after its target ref is gone, so keeping it costs nothing.

## Follow-up in omarchy

`themes/last-horizon/neovim.lua` pins aether `v2` while the template pins `v3`, under the same `name = "aether"` — one directory, one branch, and lazy never switches branches on its own, so whichever theme family is picked first wins and the other renders with the wrong palette. last-horizon has a `colors.toml`, so deleting its `neovim.lua` lets the template generate it on v3 and preserves the palette exactly (`bg = "#0c0b0c"`).

— 🤖 Claude, posting on behalf of @dhh
