### PR TITLE
Add grok-bot 0.18.0

### DIFF
--- a/pkgbuilds/grok-bot/.omarchy/package.json
+++ b/pkgbuilds/grok-bot/.omarchy/package.json
@@ -1,0 +1,5 @@
+{
+  "source": "aur",
+  "sync": false,
+  "upstream_commit": "05eb78fca06b482affda28b26223cbf249d4bbcd"
+}

--- a/pkgbuilds/grok-bot/PKGBUILD
+++ b/pkgbuilds/grok-bot/PKGBUILD
@@ -1,0 +1,66 @@
+# Maintainer: petrouil
+# Contributor: Omarchy
+
+pkgname=grok-bot
+pkgver=0.18.0
+pkgrel=1
+_commit=1618156107ae6cc9b7ab5dc1e3ba5ea5aa1425de
+pkgdesc='Grok Bot desktop agent'
+arch=('x86_64')
+url='https://x.ai/bot'
+license=('custom')
+depends=(
+  'at-spi2-core'
+  'gtk3'
+  'hicolor-icon-theme'
+  'libnotify'
+  'libsecret'
+  'libxss'
+  'libxtst'
+  'nss'
+  'util-linux-libs'
+  'xdg-utils'
+)
+optdepends=('libappindicator-gtk3: tray support')
+provides=('sand')
+conflicts=('sand')
+options=('!strip' '!debug')
+source=(
+  "${pkgname}_${pkgver}.deb::https://downloads.cursor.com/grokbot/stable/${_commit}/linux/x64/Grok_Bot_${pkgver}.deb"
+  'grok-bot.sh'
+  'grok-bot.desktop'
+)
+sha256sums=('380726acd4372b8a5668340f6ff7faf01b9bb1d4864d074a62ce7e461d17408b'
+            '2bdc0c7002200adce8a8676efb02733537df1388cb85c4257452009257570819'
+            'a5a8dc8e31485325c336185487b95e1e69c715f498025f1ae774532fe99290b9')
+noextract=("${pkgname}_${pkgver}.deb")
+
+package() {
+  bsdtar -xOf "${srcdir}/${pkgname}_${pkgver}.deb" data.tar.xz |
+    bsdtar -x -C "${pkgdir}" -f -
+
+  rm -rf "${pkgdir}/usr/share/doc" \
+    "${pkgdir}/usr/share/applications/sand.desktop"
+
+  install -Dm644 "${pkgdir}/usr/share/icons/hicolor/1024x1024/apps/sand.png" \
+    "${pkgdir}/usr/share/icons/hicolor/1024x1024/apps/grok-bot.png"
+  install -Dm644 "${pkgdir}/usr/share/icons/hicolor/1024x1024/apps/grok-bot.png" \
+    "${pkgdir}/usr/share/icons/hicolor/512x512/apps/grok-bot.png"
+  rm -f "${pkgdir}/usr/share/icons/hicolor/1024x1024/apps/sand.png"
+
+  install -Dm755 "${srcdir}/grok-bot.sh" "${pkgdir}/usr/bin/grok-bot"
+  ln -s grok-bot "${pkgdir}/usr/bin/sand"
+  install -Dm644 "${srcdir}/grok-bot.desktop" \
+    "${pkgdir}/usr/share/applications/grok-bot.desktop"
+
+  install -Dm644 "${pkgdir}/opt/Grok Bot/LICENSE.electron.txt" \
+    "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE.electron.txt"
+  install -Dm644 "${pkgdir}/opt/Grok Bot/LICENSES.chromium.html" \
+    "${pkgdir}/usr/share/licenses/${pkgname}/LICENSES.chromium.html"
+
+  if ! { [[ -L /proc/self/ns/user ]] && unshare --user true; }; then
+    chmod 4755 "${pkgdir}/opt/Grok Bot/chrome-sandbox"
+  else
+    chmod 0755 "${pkgdir}/opt/Grok Bot/chrome-sandbox"
+  fi
+}

--- a/pkgbuilds/grok-bot/grok-bot.desktop
+++ b/pkgbuilds/grok-bot/grok-bot.desktop
@@ -1,0 +1,13 @@
+[Desktop Entry]
+Name=Grok Bot
+Comment=Grok Bot desktop agent
+Exec=grok-bot %U
+TryExec=grok-bot
+Icon=grok-bot
+Terminal=false
+Type=Application
+Categories=Development;
+MimeType=x-scheme-handler/sand;
+StartupWMClass=Grok Bot
+StartupNotify=true
+Keywords=Grok;AI;Agent;

--- a/pkgbuilds/grok-bot/grok-bot.sh
+++ b/pkgbuilds/grok-bot/grok-bot.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+XDG_CONFIG_HOME=${XDG_CONFIG_HOME:-~/.config}
+
+export ELECTRON_OZONE_PLATFORM_HINT="${ELECTRON_OZONE_PLATFORM_HINT:-wayland}"
+export NIXOS_OZONE_WL="${NIXOS_OZONE_WL:-1}"
+
+if [[ -f $XDG_CONFIG_HOME/grok-bot-flags.conf ]]; then
+	GROK_BOT_USER_FLAGS="$(sed 's/#.*//' "$XDG_CONFIG_HOME/grok-bot-flags.conf" | tr '\n' ' ')"
+fi
+
+exec "/opt/Grok Bot/sand" \
+	--ozone-platform=wayland \
+	--enable-features=UseOzonePlatform,WaylandWindowDecorations \
+	--enable-wayland-ime \
+	"$@" $GROK_BOT_USER_FLAGS

--- a/pkgbuilds/grok-bot/update-pkgver.sh
+++ b/pkgbuilds/grok-bot/update-pkgver.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Resolve current Grok Bot stable from Cursor's update feed and pin PKGBUILD.
+# Linux has no latest alias (linux-x64 feed returns 204). The darwin-arm64
+# sand feed publishes version + commit; the Linux .deb lives at the same commit.
+# Darwin can ship first — HEAD-check the Linux URL and fail loudly if 404.
+set -euo pipefail
+
+PKGBUILD_PATH="${1:-PKGBUILD}"
+[[ -f "${PKGBUILD_PATH}" ]] || { echo "Error: PKGBUILD not found at '${PKGBUILD_PATH}'" >&2; exit 1; }
+
+FEED='https://api2.cursor.sh/updates/api/update/darwin-arm64/sand/0.0.0/00000000-0000-0000-0000-000000000000/stable'
+json="$(curl -fsSL -H 'cache-control: no-cache' "${FEED}")"
+
+ver="$(jq -er '.name // .version' <<<"${json}")"
+feed_url="$(jq -er '.url' <<<"${json}")"
+commit="$(sed -nE 's@.*/(grokbot|sand)/stable/([0-9a-f]{40})/.*@\2@p' <<<"${feed_url}")"
+
+[[ -n "${ver}" && -n "${commit}" ]] || {
+  echo "Error: could not parse version/commit from feed: ${json}" >&2
+  exit 1
+}
+
+deb_url="https://downloads.cursor.com/grokbot/stable/${commit}/linux/x64/Grok_Bot_${ver}.deb"
+code="$(curl -fsSIL -o /dev/null -w '%{http_code}' "${deb_url}")"
+[[ "${code}" == "200" ]] || {
+  echo "Error: Linux deb not fetchable (${code}): ${deb_url}" >&2
+  exit 1
+}
+
+tmp="$(mktemp)"
+trap 'rm -f "${tmp}"' EXIT
+curl -fL --retry 3 -o "${tmp}" "${deb_url}"
+sum="$(sha256sum "${tmp}" | awk '{print $1}')"
+
+current_ver="$(sed -nE 's/^pkgver=([^[:space:]#]+).*/\1/p' "${PKGBUILD_PATH}" | head -n1)"
+
+sed -i -E \
+  -e "s/^_commit=.*/_commit=${commit}/" \
+  -e "s/^pkgver=.*/pkgver=${ver}/" \
+  -e "0,/^[[:space:]]*'[0-9a-f]{64}'/s//    '${sum}'/" \
+  "${PKGBUILD_PATH}"
+
+if [[ "${ver}" != "${current_ver}" ]]; then
+  sed -i -E 's/^pkgrel=.*/pkgrel=1/' "${PKGBUILD_PATH}"
+fi
+
+echo "${ver} ${commit}"
+echo "${deb_url}"
+echo "${sum}"


### PR DESCRIPTION
Package the official Grok Bot Linux `.deb` (internal name `sand`) so Arch/Omarchy can install it without `dpkg`.

- Extracts `https://downloads.cursor.com/grokbot/stable/<commit>/linux/x64/Grok_Bot_<ver>.deb` with `bsdtar`
- Installs `/usr/bin/grok-bot` with native Wayland / decorations / IME
- Desktop entry and icons named `grok-bot` (upstream ships `sand`)
- `sand` kept as a compatibility symlink
- Edge only — not `release_ring: fast`
- AUR origin, sync disabled (AUR still points at a 403 0.16.0 URL)

Linux has no latest alias (`linux-x64` sand feed returns 204). `update-pkgver.sh` takes version+commit from the darwin-arm64 sand feed and HEAD-checks the Linux deb before pinning, so a mac-ahead-of-linux commit fails loudly instead of writing a 404 URL.

Built and launched on Hyprland: `class=grok-bot`, `xwayland=false`, exe `/opt/Grok Bot/sand`. Linux desktop is still unofficial; `sand` has dumped core on this machine.