### PR TITLE
Install omarchy-network-portal-watch.service

### DIFF
--- a/pkgbuilds/omarchy-settings-dev/PKGBUILD
+++ b/pkgbuilds/omarchy-settings-dev/PKGBUILD
@@ -170,6 +170,7 @@ package() {
   install -Dm644 default/systemd/user/omarchy-tailscale-receive.service "$pkgdir/usr/lib/systemd/user/omarchy-tailscale-receive.service"
   install -Dm644 default/systemd/user/omarchy-fcitx5.service "$pkgdir/usr/lib/systemd/user/omarchy-fcitx5.service"
   install -Dm644 default/systemd/user/omarchy-crash-watch.service "$pkgdir/usr/lib/systemd/user/omarchy-crash-watch.service"
+  install -Dm644 default/systemd/user/omarchy-network-portal-watch.service "$pkgdir/usr/lib/systemd/user/omarchy-network-portal-watch.service"
   # Marks app.slice (and only app.slice) as a systemd-oomd kill candidate, so
   # memory pressure costs one app scope instead of the compositor session.
   # Thresholds live in etc/systemd/oomd.conf.d/10-omarchy.conf.

--- a/pkgbuilds/omarchy-settings/PKGBUILD
+++ b/pkgbuilds/omarchy-settings/PKGBUILD
@@ -165,6 +165,7 @@ package() {
   install -Dm644 default/systemd/user/omarchy-tailscale-receive.service "$pkgdir/usr/lib/systemd/user/omarchy-tailscale-receive.service"
   install -Dm644 default/systemd/user/omarchy-fcitx5.service "$pkgdir/usr/lib/systemd/user/omarchy-fcitx5.service"
   install -Dm644 default/systemd/user/omarchy-crash-watch.service "$pkgdir/usr/lib/systemd/user/omarchy-crash-watch.service"
+  install -Dm644 default/systemd/user/omarchy-network-portal-watch.service "$pkgdir/usr/lib/systemd/user/omarchy-network-portal-watch.service"
   # Marks app.slice (and only app.slice) as a systemd-oomd kill candidate, so
   # memory pressure costs one app scope instead of the compositor session.
   # Thresholds live in etc/systemd/oomd.conf.d/10-omarchy.conf.


### PR DESCRIPTION
basecamp/omarchy#6807 adds `omarchy-network-portal-watch.service`, a session watcher that announces networks behind a captive portal. `omarchy-settings` installs user units explicitly and `enable-user-units.sh` enables the watcher on first run, so the packages need this line before that PR lands — without it first run aborts under `set -euo pipefail`.

One identical line added to both `omarchy-settings` and `omarchy-settings-dev`, right beside the other user units.

🤖 Generated with [Claude Code](https://claude.com/claude-code)