### PR TITLE
Automate tag-driven omarchy releases

### DIFF
--- a/.github/workflows/release-omarchy.yml
+++ b/.github/workflows/release-omarchy.yml
@@ -1,0 +1,100 @@
+name: Release Omarchy
+
+# Cuts the omarchy + omarchy-settings release pair automatically when a new
+# release tag appears on basecamp/omarchy. Tagging upstream is the human act;
+# this workflow runs `bin/omarchy-pkgs release latest` and pushes the PKGBUILD
+# bump to master, where the build host's 6-hourly auto-release timer picks it
+# up and publishes to edge. Promoting a final to stable stays manual
+# (`bin/repo migrate`).
+
+on:
+  schedule:
+    # Hourly tag poll. End-to-end latency is dominated by the build host's
+    # 6-hourly timer, so polling faster buys nothing.
+    - cron: '15 * * * *'
+  workflow_dispatch:
+    inputs:
+      target:
+        description: 'Release target (latest, vX.Y.Z, or vX.Y.Z-rcN)'
+        required: false
+        default: 'latest'
+  repository_dispatch:
+    types: [omarchy-release]
+
+concurrency:
+  group: release-omarchy
+  cancel-in-progress: false
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: master
+
+      - name: Cut release
+        env:
+          TARGET: ${{ github.event.inputs.target || github.event.client_payload.target || 'latest' }}
+        run: |
+          docker run --rm \
+            -e TARGET="$TARGET" \
+            -e HOST_UID="$(id -u)" \
+            -e HOST_GID="$(id -g)" \
+            -v "$PWD:/workspace" \
+            -w /workspace \
+            archlinux:base-devel bash -lc '
+              set -euo pipefail
+
+              pacman -Syu --noconfirm git
+
+              groupadd -g "$HOST_GID" runner
+              useradd -m -u "$HOST_UID" -g "$HOST_GID" runner
+              runuser -u runner -- git config --global user.name "omarchy-release-bot"
+              runuser -u runner -- git config --global user.email "bot@omarchy.org"
+
+              # --if-newer keeps scheduled polls green when there is nothing
+              # new; an explicitly dispatched target should fail loudly.
+              extra=()
+              if [[ "$TARGET" == "latest" ]]; then extra=(--if-newer); fi
+              runuser -u runner -- ./bin/omarchy-pkgs release "$TARGET" "${extra[@]}" --yes --no-push
+            '
+
+      - name: Push release commit
+        id: push
+        run: |
+          if [[ -n "$(git log origin/master..HEAD --oneline)" ]]; then
+            git push origin HEAD:master
+            echo "released=$(git log -1 --format=%s)" >> "$GITHUB_OUTPUT"
+          else
+            echo "Nothing to release."
+          fi
+
+      - name: Notify Basecamp on release
+        if: steps.push.outputs.released != '' && env.BASECAMP_CHATBOT_URL != ''
+        env:
+          BASECAMP_CHATBOT_URL: ${{ secrets.BASECAMP_CHATBOT_URL }}
+          RELEASED: ${{ steps.push.outputs.released }}
+        run: |
+          curl -s -o /dev/null \
+            -H "Content-Type: application/json" \
+            -d "$(jq -n --arg content \
+              "📦 <strong>${RELEASED}</strong> cut to edge — the build host publishes it on the next auto-release cycle" \
+              '{content: $content}')" \
+            "$BASECAMP_CHATBOT_URL"
+
+      - name: Notify Basecamp on failure
+        if: failure() && env.BASECAMP_CHATBOT_URL != ''
+        env:
+          BASECAMP_CHATBOT_URL: ${{ secrets.BASECAMP_CHATBOT_URL }}
+        run: |
+          curl -s -o /dev/null \
+            -H "Content-Type: application/json" \
+            -d "$(jq -n --arg content \
+              "🔴 <strong>Omarchy release cut failed</strong><br><a href=\"${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}\">View run</a>" \
+              '{content: $content}')" \
+            "$BASECAMP_CHATBOT_URL"

--- a/README.md
+++ b/README.md
@@ -248,6 +248,22 @@ bin/sync-aur yay v4l2-relayd            # Sync specific packages
 
 AUR sync is metadata-driven. It preserves `.omarchy/`, replaces the package root with AUR contents, applies `.omarchy/patches/*.patch`, runs `.omarchy/post-sync.sh` when present, applies pkgrel metadata, removes AUR-only `.SRCINFO` and `.gitignore` files, and records `upstream_commit`.
 
+### Releasing Omarchy
+
+```bash
+bin/omarchy-pkgs release latest         # Cut the newest upstream tag
+bin/omarchy-pkgs release v4.0.0         # Cut a specific version
+bin/omarchy-pkgs release rc             # Untagged RC from the tip of quattro
+```
+
+Tag-driven releases are automated: the `Release Omarchy` GitHub workflow polls
+basecamp/omarchy hourly and runs `release latest --if-newer` when a new release
+tag appears, pushing the PKGBUILD bump to master. The build host's auto-release
+timer then builds and publishes it to edge. Tagging upstream is the only human
+step for an edge release; promoting a final to stable stays manual
+(`bin/repo migrate`). Untagged RCs from bare commits remain a manual
+`bin/omarchy-pkgs release rc` away.
+
 ### Other
 
 ```bash

--- a/bin/omarchy-pkgs
+++ b/bin/omarchy-pkgs
@@ -45,6 +45,8 @@ Options for release:
                     the current PKGBUILD pkgver)
   --commit <sha>    (rc) Upstream commit to pin (default: tip of --ref)
   --ref <branch>    (rc) Upstream branch whose tip to pin (default: $DEFAULT_RC_REF)
+  --if-newer        (latest) Exit 0 quietly when the newest upstream tag is
+                    not newer than the current PKGBUILD — for automation
   --yes             Skip confirmation prompts
   --host <host>     ssh destination of the repository host to trigger,
                     overriding \$OMARCHY_REPO_HOST and .repo-host
@@ -335,10 +337,11 @@ trigger_build_host() {
 # --- release command ---------------------------------------------------------
 
 cmd_release() {
-  local target="" target_arg="" base="" commit_arg="" ref="" dry_run=false assume_yes=false no_push=false open_pr=false rebuild=false force=false
+  local target="" target_arg="" base="" commit_arg="" ref="" dry_run=false assume_yes=false no_push=false open_pr=false rebuild=false force=false if_newer=false
   while [[ $# -gt 0 ]]; do
     case $1 in
     --base) base="$2"; shift 2 ;;
+    --if-newer) if_newer=true; shift ;;
     --no-push) no_push=true; shift ;;
     --pr) open_pr=true; shift ;;
     --rebuild) rebuild=true; shift ;;
@@ -377,6 +380,10 @@ cmd_release() {
     print_error "--commit/--ref do not apply to 'release latest'"
     exit 1
   fi
+  if [[ "$if_newer" == true && "$target" != "latest" ]]; then
+    print_error "--if-newer only applies to 'release latest' (explicit targets should fail loudly)"
+    exit 1
+  fi
 
   print_header "Omarchy Release"
 
@@ -408,6 +415,23 @@ cmd_release() {
     fi
     pkgver=$(normalize_tag "$tag")
     commit=$(resolve_tag_commit "$tag")
+    # Automation guard: between releases the newest tag legitimately predates
+    # or matches the current PKGBUILD. Both no-op here, before the ordering
+    # guard fetches the edge DB, so an idle poll cannot fail on a DB outage.
+    # Same version + new commit still re-releases (a moved tag is news).
+    if [[ "$if_newer" == true ]]; then
+      local if_newer_current if_newer_commit
+      if_newer_current=$(pkgbuild_var "${RELEASE_PACKAGES[0]}" pkgver)
+      if_newer_commit=$(pkgbuild_var "${RELEASE_PACKAGES[0]}" _commit)
+      if (( $(vercmp "$pkgver" "$if_newer_current") < 0 )); then
+        print_success "Nothing to release — newest upstream tag $tag ($pkgver) predates current $if_newer_current"
+        exit 0
+      fi
+      if [[ "$pkgver" == "$if_newer_current" && "$commit" == "$if_newer_commit" ]]; then
+        print_success "Nothing to release — omarchy is already at $pkgver from commit ${commit:0:12}"
+        exit 0
+      fi
+    fi
     ;;
   rc | beta | alpha)
     local channel="$target"


### PR DESCRIPTION
Cutting an omarchy release currently means someone runs `bin/omarchy-pkgs release` by hand after tagging basecamp/omarchy — v4.0.0 sat tagged upstream for a day before the bump landed here. This automates that step, making the upstream tag the only human act for an edge release.

## How it works

- A new `Release Omarchy` workflow polls basecamp/omarchy hourly for release tags (plus `workflow_dispatch` with an explicit target, and a `repository_dispatch` hook if we ever want instant triggers from upstream).
- It runs `bin/omarchy-pkgs release latest --if-newer --yes --no-push` in an `archlinux:base-devel` container (same docker pattern as `sync-aur.yml`), then pushes the resulting bump commit to master.
- The build host's existing 6-hourly check-versions/auto-release timers pick the bump up from master and publish to edge, so polling faster than hourly buys nothing.
- Stable promotion is untouched and stays manual via `bin/repo migrate`, keeping full automation scoped to edge. Untagged RCs from bare commits also remain a manual `release rc` away.
- On a successful cut or a failure, the workflow posts to the Basecamp chatbot via the existing `BASECAMP_CHATBOT_URL` secret.

## The new `--if-newer` flag

Between releases the newest upstream tag legitimately predates or matches the current PKGBUILD (RCs are cut from bare commits), and `release latest` exits 1 there — which would redden every scheduled poll. `--if-newer` turns both idle cases into a quiet exit 0, before the ordering guard fetches the edge DB, so an idle poll can't fail on a transient DB outage either. A moved tag at the same version still re-releases with a pkgrel bump, and explicit targets still fail loudly (the flag is rejected outside `latest`).

Note: the push step needs master to accept pushes from the workflow's `GITHUB_TOKEN` (the repo's Actions write permission covers it unless branch protection says otherwise).

🤖 Generated with [Claude Code](https://claude.com/claude-code)