### PR TITLE
Add Dell XPS 13 sidecar amplifier workaround

### DIFF
--- a/pkgbuilds/dell-xps13-sidecar-amps/.omarchy/package.json
+++ b/pkgbuilds/dell-xps13-sidecar-amps/.omarchy/package.json
@@ -1,0 +1,3 @@
+{
+  "source": "local"
+}

--- a/pkgbuilds/dell-xps13-sidecar-amps/LICENSE
+++ b/pkgbuilds/dell-xps13-sidecar-amps/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Spencer Bull
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/pkgbuilds/dell-xps13-sidecar-amps/PKGBUILD
+++ b/pkgbuilds/dell-xps13-sidecar-amps/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=dell-xps13-sidecar-amps
 pkgver=1.0.0
-pkgrel=1
+pkgrel=2
 pkgdesc="Temporary sidecar speaker amplifier enablement for the Dell XPS 13 DX13260"
 arch=('x86_64')
 url="https://github.com/omacom-io/omarchy-pkgs"
@@ -12,17 +12,21 @@ optdepends=('limine-mkinitcpio-hook: rebuild Limine Unified Kernel Images')
 install=dell-xps13-sidecar-amps.install
 options=('!debug')
 source=(
+  'dell-xps13-sidecar-amps-apply'
   'dell-xps13-sidecar-amps.conf'
   'dell-xps13-sidecar-amps.install'
   'LICENSE'
   'README.md'
 )
-sha256sums=('dcef05d30c15b70943e621325d813980894c4c9d646aafe645e73e194f47f9d7'
-            '69d054e8e156c3449b53a972cde429216bad17841c6937228106ba2102b29e14'
+sha256sums=('ec5484486468c483b5a5acc50cd5a0dc5f368425c84bb88cddc95debe71d357e'
+            'dcef05d30c15b70943e621325d813980894c4c9d646aafe645e73e194f47f9d7'
+            '5573370afad9ce25e9b11501154d231e062f2d90f4a99b775bef69b6c736d35c'
             'fd9348252dda847b9b4c19e44c5ab101098c7d0470c2238857ce1e14bb63207b'
-            '95553269a76775ab28d5f376ed0f5daed06fe094e2b4357928f6bebab7731e97')
+            '82685711fcbe32bec70faa0aaf65032e0c0be4b6c8796123c171e1d7865e7771')
 
 package() {
+  install -Dm755 dell-xps13-sidecar-amps-apply \
+    "${pkgdir}/usr/bin/dell-xps13-sidecar-amps-apply"
   install -Dm644 dell-xps13-sidecar-amps.conf \
     "${pkgdir}/usr/lib/modprobe.d/dell-xps13-sidecar-amps.conf"
   install -Dm644 LICENSE \

--- a/pkgbuilds/dell-xps13-sidecar-amps/PKGBUILD
+++ b/pkgbuilds/dell-xps13-sidecar-amps/PKGBUILD
@@ -1,0 +1,32 @@
+# Maintainer: Spencer Bull <spencerbull2554@gmail.com>
+
+pkgname=dell-xps13-sidecar-amps
+pkgver=1.0.0
+pkgrel=1
+pkgdesc="Temporary sidecar speaker amplifier enablement for the Dell XPS 13 DX13260"
+arch=('x86_64')
+url="https://github.com/omacom-io/omarchy-pkgs"
+license=('MIT')
+depends=('kmod' 'mkinitcpio')
+optdepends=('limine-mkinitcpio-hook: rebuild Limine Unified Kernel Images')
+install=dell-xps13-sidecar-amps.install
+options=('!debug')
+source=(
+  'dell-xps13-sidecar-amps.conf'
+  'dell-xps13-sidecar-amps.install'
+  'LICENSE'
+  'README.md'
+)
+sha256sums=('dcef05d30c15b70943e621325d813980894c4c9d646aafe645e73e194f47f9d7'
+            '69d054e8e156c3449b53a972cde429216bad17841c6937228106ba2102b29e14'
+            'fd9348252dda847b9b4c19e44c5ab101098c7d0470c2238857ce1e14bb63207b'
+            '95553269a76775ab28d5f376ed0f5daed06fe094e2b4357928f6bebab7731e97')
+
+package() {
+  install -Dm644 dell-xps13-sidecar-amps.conf \
+    "${pkgdir}/usr/lib/modprobe.d/dell-xps13-sidecar-amps.conf"
+  install -Dm644 LICENSE \
+    "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"
+  install -Dm644 README.md \
+    "${pkgdir}/usr/share/doc/${pkgname}/README.md"
+}

--- a/pkgbuilds/dell-xps13-sidecar-amps/README.md
+++ b/pkgbuilds/dell-xps13-sidecar-amps/README.md
@@ -14,6 +14,11 @@ The package does not replace the kernel, audio firmware, or speaker tuning. It
 owns only a modprobe drop-in and rebuilds the boot images when installed,
 upgraded, or removed.
 
+`dell-xps13-sidecar-amps-apply` repeats the legacy cleanup and boot-image
+rebuild idempotently. System integrations can run it as root after installation
+when they need a directly observable success or failure status; package-manager
+scriptlet failures are otherwise only reported by Pacman.
+
 ## Removal
 
 Once every kernel you intend to boot contains the upstream commit, remove the

--- a/pkgbuilds/dell-xps13-sidecar-amps/README.md
+++ b/pkgbuilds/dell-xps13-sidecar-amps/README.md
@@ -1,0 +1,28 @@
+# Dell XPS 13 sidecar speaker amplifiers
+
+This temporary package enables the two CS35L56 sidecar speaker amplifiers on
+the Dell XPS 13 DX13260 with PCI subsystem ID `1028:0e53`.
+
+Linux commit
+[`efd80de2de9d`](https://github.com/torvalds/linux/commit/efd80de2de9d06ddf0eee55ca11b04e39bfc7cd8)
+adds this machine to the `snd_soc_sof_sdw` PCI quirk table with
+`SOC_SDW_SIDECAR_AMPS`. That commit first appears in Linux 7.2-rc5. Until the
+Arch kernel ships it, this package selects the equivalent existing driver path
+with the module's `quirk=65536` override.
+
+The package does not replace the kernel, audio firmware, or speaker tuning. It
+owns only a modprobe drop-in and rebuilds the boot images when installed,
+upgraded, or removed.
+
+## Removal
+
+Once every kernel you intend to boot contains the upstream commit, remove the
+workaround and reboot:
+
+```bash
+sudo pacman -Rns dell-xps13-sidecar-amps
+systemctl reboot
+```
+
+Removing the package deletes its modprobe drop-in and rebuilds the boot images,
+so no temporary override remains embedded in the initramfs or Limine UKIs.

--- a/pkgbuilds/dell-xps13-sidecar-amps/dell-xps13-sidecar-amps-apply
+++ b/pkgbuilds/dell-xps13-sidecar-amps/dell-xps13-sidecar-amps-apply
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+_legacy_override="/etc/modprobe.d/dell-xps13-dx13260-sidecar-amps.conf"
+_legacy_sha256="97f36bce41581ecc6b1d7963cd0dab29c7b1a107b2dd4d17db7a56094a7b7289"
+
+_remove_legacy_override() {
+  local actual_sha256 hash_output
+
+  [[ -f $_legacy_override ]] || return 0
+  if ! hash_output=$(sha256sum "$_legacy_override"); then
+    printf ':: Unable to hash legacy override: %s\n' "$_legacy_override" >&2
+    return 1
+  fi
+  actual_sha256=${hash_output%% *}
+
+  if [[ $actual_sha256 == "$_legacy_sha256" ]]; then
+    if ! rm -f -- "$_legacy_override"; then
+      printf ':: Unable to remove legacy override: %s\n' "$_legacy_override" >&2
+      return 1
+    fi
+    printf ':: Removed the superseded Dell XPS 13 sidecar amplifier override.\n'
+  else
+    printf ':: Preserving modified legacy override: %s\n' "$_legacy_override"
+  fi
+}
+
+_rebuild_boot_images() {
+  local output status
+
+  if command -v limine-mkinitcpio >/dev/null 2>&1; then
+    output=$(limine-mkinitcpio 2>&1)
+    status=$?
+    [[ -z $output ]] || printf '%s\n' "$output"
+
+    (( status == 0 )) || return "$status"
+    [[ $output != *"ERROR:"* ]] || return 1
+  elif command -v mkinitcpio >/dev/null 2>&1; then
+    mkinitcpio -P
+  else
+    printf ':: Unable to rebuild boot images: install mkinitcpio and rebuild before rebooting.\n' >&2
+    return 1
+  fi
+}
+
+apply_sidecar_amp_workaround() {
+  _remove_legacy_override || return
+  _rebuild_boot_images || return
+}
+
+if [[ ${BASH_SOURCE[0]} == "$0" ]]; then
+  if (( EUID != 0 )); then
+    printf ':: Run dell-xps13-sidecar-amps-apply as root.\n' >&2
+    exit 1
+  fi
+
+  apply_sidecar_amp_workaround
+fi

--- a/pkgbuilds/dell-xps13-sidecar-amps/dell-xps13-sidecar-amps.conf
+++ b/pkgbuilds/dell-xps13-sidecar-amps/dell-xps13-sidecar-amps.conf
@@ -1,0 +1,3 @@
+# Temporary workaround for Dell XPS 13 DX13260 subsystem 1028:0e53.
+# Remove this package once every bootable kernel contains Linux efd80de2de9d.
+options snd_soc_sof_sdw quirk=65536

--- a/pkgbuilds/dell-xps13-sidecar-amps/dell-xps13-sidecar-amps.install
+++ b/pkgbuilds/dell-xps13-sidecar-amps/dell-xps13-sidecar-amps.install
@@ -1,0 +1,60 @@
+_legacy_override="/etc/modprobe.d/dell-xps13-dx13260-sidecar-amps.conf"
+_legacy_sha256="97f36bce41581ecc6b1d7963cd0dab29c7b1a107b2dd4d17db7a56094a7b7289"
+
+_remove_legacy_override() {
+  local actual_sha256 hash_output
+
+  [ -f "$_legacy_override" ] || return 0
+  if ! hash_output=$(sha256sum "$_legacy_override"); then
+    printf ':: Unable to hash legacy override: %s\n' "$_legacy_override" >&2
+    return 1
+  fi
+  actual_sha256=${hash_output%% *}
+
+  if [ "$actual_sha256" = "$_legacy_sha256" ]; then
+    if ! rm -f -- "$_legacy_override"; then
+      printf ':: Unable to remove legacy override: %s\n' "$_legacy_override" >&2
+      return 1
+    fi
+    printf ':: Removed the superseded Dell XPS 13 sidecar amplifier override.\n'
+  else
+    printf ':: Preserving modified legacy override: %s\n' "$_legacy_override"
+  fi
+}
+
+_rebuild_boot_images() {
+  local output status
+
+  if command -v limine-mkinitcpio >/dev/null 2>&1; then
+    output=$(limine-mkinitcpio 2>&1)
+    status=$?
+    [ -z "$output" ] || printf '%s\n' "$output"
+
+    [ "$status" -eq 0 ] || return "$status"
+    case "$output" in
+      *"ERROR:"*) return 1 ;;
+    esac
+  elif command -v mkinitcpio >/dev/null 2>&1; then
+    mkinitcpio -P
+  else
+    printf ':: Unable to rebuild boot images: install mkinitcpio and rebuild before rebooting.\n' >&2
+    return 1
+  fi
+}
+
+post_install() {
+  _remove_legacy_override || return
+  _rebuild_boot_images || return
+  printf ':: Reboot to enable the Dell XPS 13 sidecar speaker amplifiers.\n'
+}
+
+post_upgrade() {
+  _remove_legacy_override || return
+  _rebuild_boot_images || return
+  printf ':: Reboot to apply the Dell XPS 13 sidecar amplifier update.\n'
+}
+
+post_remove() {
+  _rebuild_boot_images || return
+  printf ':: Reboot to finish removing the Dell XPS 13 sidecar amplifier workaround.\n'
+}

--- a/pkgbuilds/dell-xps13-sidecar-amps/dell-xps13-sidecar-amps.install
+++ b/pkgbuilds/dell-xps13-sidecar-amps/dell-xps13-sidecar-amps.install
@@ -1,26 +1,4 @@
-_legacy_override="/etc/modprobe.d/dell-xps13-dx13260-sidecar-amps.conf"
-_legacy_sha256="97f36bce41581ecc6b1d7963cd0dab29c7b1a107b2dd4d17db7a56094a7b7289"
-
-_remove_legacy_override() {
-  local actual_sha256 hash_output
-
-  [ -f "$_legacy_override" ] || return 0
-  if ! hash_output=$(sha256sum "$_legacy_override"); then
-    printf ':: Unable to hash legacy override: %s\n' "$_legacy_override" >&2
-    return 1
-  fi
-  actual_sha256=${hash_output%% *}
-
-  if [ "$actual_sha256" = "$_legacy_sha256" ]; then
-    if ! rm -f -- "$_legacy_override"; then
-      printf ':: Unable to remove legacy override: %s\n' "$_legacy_override" >&2
-      return 1
-    fi
-    printf ':: Removed the superseded Dell XPS 13 sidecar amplifier override.\n'
-  else
-    printf ':: Preserving modified legacy override: %s\n' "$_legacy_override"
-  fi
-}
+_apply_command="/usr/bin/dell-xps13-sidecar-amps-apply"
 
 _rebuild_boot_images() {
   local output status
@@ -43,14 +21,12 @@ _rebuild_boot_images() {
 }
 
 post_install() {
-  _remove_legacy_override || return
-  _rebuild_boot_images || return
+  "$_apply_command" || return
   printf ':: Reboot to enable the Dell XPS 13 sidecar speaker amplifiers.\n'
 }
 
 post_upgrade() {
-  _remove_legacy_override || return
-  _rebuild_boot_images || return
+  "$_apply_command" || return
   printf ':: Reboot to apply the Dell XPS 13 sidecar amplifier update.\n'
 }
 


### PR DESCRIPTION
## Summary

- add a removable `dell-xps13-sidecar-amps` x86_64 package for the Dell XPS 13 DX13260 with subsystem ID `1028:0e53`
- select the existing `SOC_SDW_SIDECAR_AMPS` driver path through `snd_soc_sof_sdw quirk=65536`
- rebuild Limine UKIs or mkinitcpio presets on install, upgrade, and removal
- migrate the exact legacy local override while preserving any modified user-owned version
- provide a root-only, idempotent `dell-xps13-sidecar-amps-apply` command so system integrations can directly observe cleanup and rebuild failures
- document the Linux 7.2 removal gate and install package documentation and licensing

## Why

Linux commit [`efd80de2de9d`](https://github.com/torvalds/linux/commit/efd80de2de9d06ddf0eee55ca11b04e39bfc7cd8) adds this exact machine to the SOF SoundWire quirk table with `SOC_SDW_SIDECAR_AMPS`. It first appears in Linux 7.2-rc5. Arch currently ships Linux 7.1.8, so the XPS 13 sidecar amplifiers remain disabled without a temporary override.

This package provides an independently removable compatibility layer. Once every bootable kernel contains the upstream commit, removing the package deletes the modprobe drop-in and rebuilds the boot images. It does not replace the kernel, firmware, or speaker tuning.

Version `1.0.0-2` exposes the apply step as an idempotent command. Pacman reports package scriptlet failures but libalpm does not propagate them through the transaction status, so Omarchy can invoke this command after installation and fail its migration reliably if legacy cleanup or boot-image rebuilding fails.

## Validation

### Packaging

- rebased onto current `omacom-io/omarchy-pkgs:master`
- direct `makepkg --cleanbuild --clean --force`
- repository-native `bin/repo build --package dell-xps13-sidecar-amps`: 1 built, 0 failed
- x86_64 selected and aarch64 excluded by repository dry runs
- package payload, source checksums, Bash syntax, ShellCheck 0.11, and `git diff --check`
- eight lifecycle fixture cases covering the root guard, exact legacy migration, preservation of modified files, hash and removal failures, masked Limine per-kernel errors, mkinitcpio fallback, and rebuild failure propagation
- cross-repository Omarchy retry/failure matrix confirms explicit apply failures stay observable after Pacman registers the package
- independent findings-first review completed clean after resolving the ALPM scriptlet-status boundary

### Live Dell XPS 13 DX13260

Hardware enablement was previously tested on SKU `0E53` running Arch Linux `7.1.8-arch1-3` with package `1.0.0-1`:

- installed with zero altered package files
- Limine UKI rebuilt successfully and the machine rebooted normally
- loaded module parameter changed from `-1` to `65536`
- both left and right CS35L56 amplifiers bound successfully
- exact `1028:0e53` DSP firmware loaded and calibration applied to both amplifiers
- low-level sweep targeted the physical internal SOF/SoundWire speaker sink; both amplifiers were active and no playback-time audio errors or failed units appeared

The `1.0.0-2` change is limited to making the existing cleanup/rebuild operation directly callable and observable; it was not reinstalled on the live device during this review. A live uninstall-and-reboot remains intentionally skipped because it would disable the now-working amplifiers; removal and rebuild behavior is covered by the lifecycle fixture.