### PR TITLE
Update omatrack to 1.2.0

### DIFF
--- a/pkgbuilds/omatrack/PKGBUILD
+++ b/pkgbuilds/omatrack/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: David Heinemeier Hansson <david@hey.com>
 
 pkgname=omatrack
-pkgver=0.9.11
+pkgver=1.2.0
 pkgrel=1
 pkgdesc="Cross-format motorsport telemetry analysis workstation"
 arch=('x86_64' 'aarch64')
@@ -11,9 +11,9 @@ depends=('qt6-base' 'qt6-declarative' 'mpv' 'libyaml' 'gcc-libs' 'glibc' 'hicolo
 makedepends=('cmake' 'ninja' 'rust')
 options=('!debug' '!lto')
 
-_commit=122c59f3911289c7ae4b11ecb0d5992699b08d75
+_commit=ebe7f4f6b05845a85a2b713f889e676442fd0e82
 source=("omatrack-$_commit.tar.gz::$url/archive/$_commit.tar.gz")
-sha256sums=('3a2d457cb7c85d62147d98f2896e2b157a20f40f88b5496ae56b236b3337209a')
+sha256sums=('8e6c62de5f8c98239a84abe9696c83f1155bef12004ee2c028bd99d64b8263a4')
 
 prepare() {
   cd "omatrack-$_commit/third_party/motorsport-telemetry"


### PR DESCRIPTION
## Summary

Updates Omatrack from 0.9.11 to 1.2.0, pinned to the signed `v1.2.0` release commit (`ebe7f4f6b05845a85a2b713f889e676442fd0e82`).

This is the Arch package bump. Portable AppImage / Windows / macOS builds self-update from GitHub Releases; the pacman package still comes through this repo.

## Changelog since 0.9.11

### 1.2.0

- Portable Linux AppImages, Windows Velopack installs, and macOS apps check GitHub Releases from the header. Later snoozes the prompt for a week and leaves the update icon. Updates verify `SHA256SUMS.txt` before replacing the running build. From-source / packaged builds do not self-update.
- Windows ships a per-user Velopack installer (no UAC) with `Update.exe` apply. First run asks about file associations: `.pds` / `.ld` / `.vbo` / `.telemetry` default on, `.mp4` default off.

### 1.1.0

- Native `.telemetry` is the only persisted analysis file. First open of a `.pds` / `.ld` / `.vbo` / AiM video writes hidden `.{filename}.telemetry`; later opens read that.
- Zoomed traces are polylines through the 50 Hz samples; zoomed-out envelopes stay a device-pixel min/max column.
- Primary onboard video is the clock at 1×. Reaching the end of a lap counts down 3-2-1 and continues to the next lap. Reference video holds 1× through corners and uses the next straight to stay aligned.
- Fullscreen video has five compose layouts (1–5), pip insets, `S` for 0.25×, a live delta bar, and a HUD that follows track-station progress.
- Library rows group by day and show session / driver instead of the filename.
- Comparison Δt is time at the same 50 Hz lap-progress station.

Release: https://github.com/tobi/omatrack/releases/tag/v1.2.0

## Package changes

- `pkgver`: `0.9.11` → `1.2.0`
- `_commit`: `122c59f3…` → `ebe7f4f6…`
- Updated the SHA-256 checksum for the pinned GitHub source archive.

## Validation

- Upstream Omatrack [release run](https://github.com/tobi/omatrack/actions/runs/31910674325): passed (Linux AppImage, Windows Velopack, macOS dmg, published `v1.2.0`).
- `bash -n PKGBUILD`: passed.
- `makepkg --verifysource`: checksum passed.