### PR TITLE
feat(mise-bin): add optimized mise binaries

### DIFF
--- a/pkgbuilds/mise-bin/.omarchy/package.json
+++ b/pkgbuilds/mise-bin/.omarchy/package.json
@@ -1,0 +1,4 @@
+{
+  "source": "local",
+  "release_ring": "fast"
+}

--- a/pkgbuilds/mise-bin/.omarchy/upstream.sh
+++ b/pkgbuilds/mise-bin/.omarchy/upstream.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+set -euo pipefail
+
+repo="jdx/mise"
+release=$(curl -fsSL "https://api.github.com/repos/$repo/releases/latest")
+tag=$(jq -r '.tag_name // empty' <<<"$release")
+
+if [[ ! "$tag" =~ ^v([A-Za-z0-9._+]+)$ ]]; then
+  echo "Latest mise release has an invalid tag: ${tag:-<empty>}" >&2
+  exit 1
+fi
+
+pkgver=${BASH_REMATCH[1]}
+checksums=$(curl -fsSL \
+  "https://github.com/$repo/releases/download/$tag/SHASUMS256.txt")
+
+checksum_for() {
+  local filename=$1
+  local checksum
+  checksum=$(awk -v filename="./$filename" '$2 == filename { print $1 }' <<<"$checksums")
+
+  if [[ ! "$checksum" =~ ^[0-9a-f]{64}$ ]]; then
+    echo "No valid checksum found for $filename in $tag" >&2
+    exit 1
+  fi
+
+  echo "$checksum"
+}
+
+x86_64=$(checksum_for "mise-v${pkgver}-linux-x64.tar.xz")
+aarch64=$(checksum_for "mise-v${pkgver}-linux-arm64.tar.xz")
+
+jq -n \
+  --arg pkgver "$pkgver" \
+  --arg x86_64 "$x86_64" \
+  --arg aarch64 "$aarch64" \
+  '{pkgver: $pkgver, sha256sums: {x86_64: [$x86_64], aarch64: [$aarch64]}}'

--- a/pkgbuilds/mise-bin/PKGBUILD
+++ b/pkgbuilds/mise-bin/PKGBUILD
@@ -1,0 +1,37 @@
+# Maintainer: Jeff Dickey <releases@mise.jdx.dev>
+pkgname=mise-bin
+pkgver=2026.8.6
+pkgrel=1
+pkgdesc="dev tools, env vars, task runner"
+arch=('x86_64' 'aarch64')
+url="https://github.com/jdx/mise"
+license=('MIT')
+options=('!debug')
+optdepends=(
+    'bash-completion: bash completion support'
+)
+provides=('mise')
+conflicts=('mise')
+source_x86_64=("https://github.com/jdx/mise/releases/download/v${pkgver}/mise-v${pkgver}-linux-x64.tar.xz")
+source_aarch64=("https://github.com/jdx/mise/releases/download/v${pkgver}/mise-v${pkgver}-linux-arm64.tar.xz")
+sha256sums_x86_64=('263bad5fd24b82293645d5e5314a8090de2e52391a7f6713784e8aa519a420b7')
+sha256sums_aarch64=('dfdb41a4654f473f504625ffa1e011e119e5fd1880ccbed8dcb0b21a58ccd309')
+
+package() {
+    install -Dm755 "${srcdir}/mise/bin/mise" "${pkgdir}/usr/bin/mise"
+
+    # disable mise self-update (managed by pacman)
+    install -Dm644 /dev/null "${pkgdir}/usr/lib/mise/.disable-self-update"
+
+    # man page
+    install -Dm644 "${srcdir}/mise/man/man1/mise.1" "${pkgdir}/usr/share/man/man1/mise.1"
+
+    # fish completion (bash/zsh not included in pre-built tarball)
+    install -Dm644 "${srcdir}/mise/share/fish/vendor_conf.d/mise-activate.fish" "${pkgdir}/usr/share/fish/vendor_conf.d/mise-activate.fish"
+
+    # license
+    install -Dm644 "${srcdir}/mise/LICENSE" "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"
+
+    # docs
+    install -Dm644 "${srcdir}/mise/README.md" "${pkgdir}/usr/share/doc/${pkgname}/README.md"
+}


### PR DESCRIPTION
## Summary

Add `mise-bin` to OPR using mise’s official glibc release artifacts:

- x86_64 uses the PGO+BOLT-optimized binary
- aarch64 uses the serious-profile glibc binary
- releases are tracked directly from `jdx/mise`
- `.omarchy/upstream.sh` reads checksums from the official `SHASUMS256.txt`
- OPR’s scheduled upstream sync automatically proposes new releases
- the package is published through the fast release ring

Arch is glibc-native, so the glibc release artifacts are a better fit than the musl binaries previously used by the AUR package.

## Validation

- Ran `bin/sync-upstream mise-bin`
- Tested a simulated `2026.8.5 → 2026.8.6` update
- Verified upstream sync resets `pkgrel` to `1`
- Ran ShellCheck on `.omarchy/upstream.sh`
- Built with `makepkg` in a fresh official `archlinux:base-devel` container
- Installed the resulting package with `pacman -U`
- Verified `mise --version` reports `2026.8.6 linux-x64`
- Verified the executable uses Arch’s glibc loader
- Verified `.bolt.org.*` sections are present in the installed ELF
- Verified package metadata, installed files, help output, and the self-update disable marker