### PR TITLE
Add omarchy-screensaver

### DIFF
--- a/pkgbuilds/omarchy-screensaver/.omarchy/package.json
+++ b/pkgbuilds/omarchy-screensaver/.omarchy/package.json
@@ -1,0 +1,4 @@
+{
+  "source": "local",
+  "release_ring": "fast"
+}

--- a/pkgbuilds/omarchy-screensaver/.omarchy/upstream.sh
+++ b/pkgbuilds/omarchy-screensaver/.omarchy/upstream.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+set -euo pipefail
+
+latest_url=$(curl -fsSLI -o /dev/null -w '%{url_effective}' \
+  'https://github.com/tobi/omarchy-launch-screensaver/releases/latest')
+pkgver=${latest_url##*/}
+pkgver=${pkgver#v}
+
+checksum_for() {
+  local arch="$1"
+  curl -fsSL \
+    "https://github.com/tobi/omarchy-launch-screensaver/releases/download/v${pkgver}/omarchy-launch-screensaver-linux-${arch}.tar.gz.sha256" |
+    cut -d' ' -f1
+}
+
+x86_64=$(checksum_for x86_64)
+aarch64=$(checksum_for aarch64)
+
+if [[ -z "$pkgver" || -z "$x86_64" || -z "$aarch64" ]]; then
+  echo "Latest release is missing a version or Linux asset digest" >&2
+  exit 1
+fi
+
+jq -n \
+  --arg pkgver "$pkgver" \
+  --arg x86_64 "$x86_64" \
+  --arg aarch64 "$aarch64" \
+  '{pkgver: $pkgver, sha256sums: {x86_64: [$x86_64], aarch64: [$aarch64]}}'

--- a/pkgbuilds/omarchy-screensaver/PKGBUILD
+++ b/pkgbuilds/omarchy-screensaver/PKGBUILD
@@ -1,0 +1,20 @@
+pkgname=omarchy-screensaver
+pkgver=1.0.0
+pkgrel=1
+pkgdesc='Native Wayland screensaver for Omarchy'
+arch=('x86_64' 'aarch64')
+url='https://github.com/tobi/omarchy-launch-screensaver'
+license=('MIT')
+depends=('gcc-libs' 'glibc' 'libxkbcommon')
+options=('!debug')
+
+source_x86_64=("${pkgname}-${pkgver}-x86_64.tar.gz::${url}/releases/download/v${pkgver}/omarchy-launch-screensaver-linux-x86_64.tar.gz")
+source_aarch64=("${pkgname}-${pkgver}-aarch64.tar.gz::${url}/releases/download/v${pkgver}/omarchy-launch-screensaver-linux-aarch64.tar.gz")
+sha256sums_x86_64=('92a6de18becf8c1b12877f378a2edea1394c72ad976027913858c68b041e2a00')
+sha256sums_aarch64=('fe49d43dd1a4f5d327968634fff34f35c9b0567cd12ce526590ef14073168b39')
+
+package() {
+  install -Dm755 omarchy-launch-screensaver "${pkgdir}/usr/lib/${pkgname}/omarchy-screensaver"
+  install -Dm644 LICENSE "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"
+  install -Dm644 README.md "${pkgdir}/usr/share/doc/${pkgname}/README.md"
+}


### PR DESCRIPTION
## Summary

- add the native Wayland Omarchy screensaver package
- install the release binary at `/usr/lib/omarchy-screensaver/omarchy-screensaver` for the stable launcher script
- ship x86_64 and aarch64 release assets with pinned SHA-256 checksums
- track future GitHub releases through the upstream sync hook

Omarchy integration: https://github.com/basecamp/omarchy/pull/7193

## Verification

- `makepkg --force --noconfirm`
- `bin/sync-upstream omarchy-screensaver`
- verified package payload, release checksums, and x86_64 runtime dependencies