### PR TITLE
Update ttfx to v0.3.2

### DIFF
--- a/pkgbuilds/ttfx/PKGBUILD
+++ b/pkgbuilds/ttfx/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: David Heinemeier Hansson <david@hey.com>
 
 pkgname=ttfx
-pkgver=0.3.1
+pkgver=0.3.2
 pkgrel=1
 pkgdesc="Terminal text effects as a single static binary — Rust port of terminaltexteffects"
 arch=('x86_64' 'aarch64')
@@ -12,7 +12,7 @@ makedepends=('cargo')
 options=('!debug')
 
 source=("$pkgname-$pkgver.tar.gz::$url/archive/refs/tags/v$pkgver.tar.gz")
-sha256sums=('ea01955133b8614167748b4a63cbbdd00a99135765e3194675f8f37c00faad54')
+sha256sums=('d0c0df4867e7f03142fb7f77c66670d0e8da15534239c1a7abfd89f19dfc00f6')
 
 prepare() {
   cd "$pkgname-$pkgver"


### PR DESCRIPTION
Picks up [ttfx v0.3.2](https://github.com/omacom-io/ttfx/releases/tag/v0.3.2), which stops ttfx dumping core on every idle lock ([basecamp/omarchy#6762](https://github.com/basecamp/omarchy/issues/6762)).

A terminal killed out from under a running animation used to turn into an EIO write error, which ttfx reported with `eprintln!` — to the same dead terminal. That print panicked, and release builds are `panic = "abort"`, so each lock left a ~1 MB core behind. ttfx now ends the run quietly when its terminal goes away, and can no longer die reporting anything.

Tarball sha256 verified against the release tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
