### PR TITLE
Drop "(Alpha)" from the T3 Code desktop entry

### DIFF
--- a/pkgbuilds/t3code-bin/PKGBUILD
+++ b/pkgbuilds/t3code-bin/PKGBUILD
@@ -8,7 +8,7 @@
 
 pkgname=t3code-bin
 pkgver=0.0.33
-pkgrel=1
+pkgrel=2
 pkgdesc="Open-source control plane for coding agents"
 arch=('x86_64')
 url="https://t3.codes"
@@ -92,7 +92,10 @@ package() {
 
   # Upstream's own entry rather than a hand-written one: it carries the
   # t3code:// scheme handlers that make the app's deep links resolve.
-  sed -e 's|^Exec=.*|Exec=t3code %U|' -e '/^X-AppImage-Version=/d' t3code.desktop \
+  # The name drops the "(Alpha)" upstream's electron-builder still appends; the
+  # app itself now calls that string legacy and keeps its data under t3code.
+  sed -e 's|^Exec=.*|Exec=t3code %U|' -e 's|^Name=.*|Name=T3 Code|' \
+    -e '/^X-AppImage-Version=/d' t3code.desktop \
     > "${srcdir}/t3code.desktop.arch"
   install -Dm644 "${srcdir}/t3code.desktop.arch" \
     "${pkgdir}/usr/share/applications/t3code.desktop"


### PR DESCRIPTION
The T3 Code launcher entry reads "T3 Code (Alpha)".

It comes from upstream's AppImage rather than a hand-written entry, which is deliberate — that file is what carries the `t3code://` scheme handlers the app's deep links need — and it arrives carrying electron-builder's `productName`, "T3 Code (Alpha)".

That name is stale upstream too. Their own code calls it legacy and has already moved the app's data off it:

```js
const legacyUserDataDirName = isDevelopment ? "T3 Code (Dev)" : "T3 Code (Alpha)";
```

A fresh install writes `~/.config/t3code`, not the Alpha path. So the launcher was advertising an identity upstream itself has moved on from.

Rewrite `Name=` alongside the `Exec=` rewrite already there. The scheme handlers, the MimeType line and the rest of upstream's entry are untouched.

`pkgrel` goes to 2 because 0.0.33-1 is already published, and a packaging-only change reaches an installed machine only through a new release.

🤖 Generated by Opus 5 in Claude Code.
