### PR TITLE
Require zram-generator for target Omarchy packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -398,7 +398,7 @@ bin/omarchy-pkgs release rc              # Untagged RC from the quattro tip, aut
 bin/omarchy-pkgs release --commit abc123 --base 4.1.0   # Untagged RC from a commit
 bin/omarchy-pkgs release ... --dry-run   # Show the plan; write nothing
 bin/omarchy-pkgs release ... --no-push   # Full flow, local commit only (testing)
-bin/omarchy-pkgs self-test               # Version normalization + ordering tests
+bin/omarchy-pkgs self-test               # Release invariants + package contract tests
 ```
 
 ### Versioning rules

--- a/bin/omarchy-pkgs
+++ b/bin/omarchy-pkgs
@@ -38,7 +38,7 @@ Commands:
   release beta|alpha [vX.Y.Z]    Same for beta/alpha channels
   release rc --commit <sha>      Untagged pre-release from a bare commit,
                                  auto-numbered past published edge + PKGBUILD
-  self-test                      Run version-normalization and ordering tests
+  self-test                      Run release and package-contract tests
 
 Options for release:
   --base <X.Y.Z>    (rc) Base version the RC leads up to (default: base of
@@ -589,6 +589,118 @@ cmd_release() {
 cmd_self_test() {
   local failures=0
 
+  load_package_dependency_metadata() {
+    local package="$1" destination="$2" output
+    if output=$(
+      (
+        if cd "$BUILD_ROOT/pkgbuilds/$package"; then
+          :
+        else
+          echo "package directory is unavailable" >&2
+          exit 1
+        fi
+
+        if [[ -f PKGBUILD ]]; then
+          :
+        else
+          echo "PKGBUILD is missing" >&2
+          exit 1
+        fi
+
+        unset depends
+        local variable
+        while IFS= read -r variable; do
+          unset "$variable"
+        done < <(compgen -A variable depends_)
+
+        if source PKGBUILD >/dev/null; then
+          :
+        else
+          echo "PKGBUILD could not be sourced" >&2
+          exit 1
+        fi
+
+        local -a dependency_fields=(depends)
+        while IFS= read -r variable; do
+          dependency_fields+=("$variable")
+        done < <(compgen -A variable depends_)
+
+        local declaration dependency field
+        for field in "${dependency_fields[@]}"; do
+          if declaration=$(declare -p "$field" 2>/dev/null); then
+            case $declaration in
+            "declare -a "*) ;;
+            *)
+              echo "$field must be an indexed array" >&2
+              exit 1
+              ;;
+            esac
+          else
+            echo "$field must be declared as an indexed array" >&2
+            exit 1
+          fi
+
+          local -n dependency_values="$field"
+          for dependency in "${dependency_values[@]}"; do
+            printf 'dependency\t%s\t%s\n' "$field" "$dependency"
+          done
+          unset -n dependency_values
+        done
+      ) 2>&1
+    ); then
+      printf -v "$destination" '%s' "$output"
+    else
+      echo "  FAIL: could not read dependency metadata for $package"
+      if [[ -n $output ]]; then
+        while IFS= read -r line; do
+          echo "    $line"
+        done <<< "$output"
+      fi
+      return 1
+    fi
+  }
+
+  dependency_metadata_has() {
+    local metadata="$1" dependency="$2" scope="$3"
+    local marker field declared dependency_name
+    while IFS=$'\t' read -r marker field declared; do
+      [[ $marker == "dependency" ]] || continue
+      dependency_name=${declared%%[<>=]*}
+      if [[ $dependency_name == "$dependency" && ( $scope == "all" || $field == "depends" ) ]]; then
+        return 0
+      fi
+    done <<< "$metadata"
+    return 1
+  }
+
+  check_hard_dependency() {
+    local package="$1" dependency="$2" metadata
+    if load_package_dependency_metadata "$package" metadata; then
+      if dependency_metadata_has "$metadata" "$dependency" plain; then
+        echo "  ok: $package hard-depends on $dependency in plain depends"
+      else
+        echo "  FAIL: $package must hard-depend on $dependency in plain depends"
+        failures=$((failures + 1))
+      fi
+    else
+      failures=$((failures + 1))
+    fi
+  }
+
+  check_no_hard_dependency() {
+    local package="$1" dependency="$2" metadata
+    if load_package_dependency_metadata "$package" metadata; then
+      if dependency_metadata_has "$metadata" "$dependency" all; then
+        echo "  FAIL: $package must not hard-depend on $dependency in depends or depends_*"
+        failures=$((failures + 1))
+      else
+        echo "  ok: $package does not hard-depend on $dependency in depends or depends_*"
+      fi
+    else
+      failures=$((failures + 1))
+    fi
+  }
+
   check_norm() {
     local input="$1" expected="$2" got
     got=$(normalize_tag "$input" 2>/dev/null) || got="<reject>"
@@ -652,6 +764,12 @@ cmd_self_test() {
   [[ $(version_base 4.0.0rc7) == 4.0.0 ]] && echo "  ok: version_base 4.0.0rc7 → 4.0.0" || { echo "  FAIL: version_base"; failures=$((failures + 1)); }
   version_is_rc 4.0.0rc1 && echo "  ok: 4.0.0rc1 is rc" || { echo "  FAIL: version_is_rc positive"; failures=$((failures + 1)); }
   version_is_rc 4.0.0 && { echo "  FAIL: version_is_rc negative"; failures=$((failures + 1)); } || echo "  ok: 4.0.0 is not rc"
+
+  echo "Target package contracts:"
+  check_hard_dependency omarchy zram-generator
+  check_hard_dependency omarchy-dev zram-generator
+  check_no_hard_dependency omarchy-settings zram-generator
+  check_no_hard_dependency omarchy-settings-dev zram-generator
 
   echo ""
   if [[ "$failures" -eq 0 ]]; then

--- a/pkgbuilds/omarchy-dev/PKGBUILD
+++ b/pkgbuilds/omarchy-dev/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Ryan Hughes <ryan@omarchy.org>
 pkgname='omarchy-dev'
-pkgver=4.0.0.r847.g4de185b
-pkgrel=1
+pkgver=4.0.0.r1834.g9301092
+pkgrel=2
 _pkgver_base=4.0.0
 _pkgver_base_tag=v3.8.2
 pkgdesc='Beautiful, modern, and opinionated Arch Linux by DHH (quattro branch tip)'
@@ -28,6 +28,10 @@ depends=(
   'limine-mkinitcpio-hook'
   'limine-snapper-sync'
   'snapper'
+
+  # Memory-pressure protection. omarchy-settings-dev ships the zram config but
+  # stays live-ISO safe by leaving this target-only dependency here.
+  'zram-generator'
 
   # Wayland / Hyprland core
   'hyprland'

--- a/pkgbuilds/omarchy/PKGBUILD
+++ b/pkgbuilds/omarchy/PKGBUILD
@@ -13,7 +13,7 @@ pkgname='omarchy'
 _tag='v4.0.1'
 _commit='13f18b2cb7286fb54f87daf571a031aa6af3d8f0'
 pkgver=4.0.1
-pkgrel=1
+pkgrel=2
 pkgdesc='Beautiful, modern, and opinionated Arch Linux by DHH'
 arch=('any')
 url='https://github.com/basecamp/omarchy'
@@ -42,6 +42,10 @@ depends=(
   'limine-mkinitcpio-hook'
   'limine-snapper-sync'
   'snapper'
+
+  # Memory-pressure protection. omarchy-settings ships the zram config but
+  # stays live-ISO safe by leaving this target-only dependency here.
+  'zram-generator'
 
   # Wayland / Hyprland core
   'hyprland'


### PR DESCRIPTION
## Summary

- Require `zram-generator` from the stable and development target packages.
- Keep the settings packages safe for the live ISO by leaving zram optional there.
- Add package-contract checks for both sides of that boundary, including architecture-specific dependency arrays.
- Rebuild the stable and development packages at revision 2.

## Root cause

`omarchy-settings` ships `/usr/lib/systemd/zram-generator.conf.d/90-omarchy.conf`, but neither target package installed the generator that reads it. Non-ISO installs could therefore boot without swap while systemd-oomd was enabled.

The dependency belongs on `omarchy` and `omarchy-dev`, not the settings packages, because settings is also installed in the live ISO environment.

Fixes basecamp/omarchy#7522.

## Package revisions

- `omarchy 4.0.1-2`
- `omarchy-dev 4.0.0.r1834.g9301092-2`

## Validation

- `bin/omarchy-pkgs self-test`
- `bash -n` on the CLI and all four relevant PKGBUILDs
- generated `.SRCINFO` checks for all four relevant packages
- isolated unsigned builds of `omarchy-4.0.1-2-any` and `omarchy-dev-4.0.0.r1834.g9301092-2-any`
- inspected both built `.PKGINFO` files for exactly one `depend = zram-generator`
- source-side package contract and mutation matrix: architecture-only target dependencies fail; target dependencies in plain `depends` pass; settings hard dependencies fail in plain and architecture-specific arrays
- root/read-only Arch Linux ARM workflow equivalent

## CI status

The branch is rebased on package `master` at `0ea0c5f8` and is clean and mergeable. Reviewed tree: `9ebdf0d85cbc4c9ea7019d6c2e07e9d9a2d02233`.

The repository's Tests workflow passed on GitHub's x86_64 runner against exact head `4dd8c641`. The upstream pull-request run is waiting for maintainer approval before GitHub creates its job.
