### PR TITLE
Add omarchy-quake (Quake 1: vkQuake, Omarchy panel, Tailscale deathmatch)

### DIFF
--- a/pkgbuilds/omarchy-quake/.omarchy/package.json
+++ b/pkgbuilds/omarchy-quake/.omarchy/package.json
@@ -1,0 +1,3 @@
+{
+  "source": "local"
+}

--- a/pkgbuilds/omarchy-quake/PKGBUILD
+++ b/pkgbuilds/omarchy-quake/PKGBUILD
@@ -1,0 +1,65 @@
+# Maintainer: Ryan Robitaille <ryan.robitaille@gmail.com>
+# Draft for omacom-io/omarchy-pkgs (pkgbuilds/omarchy-quake).
+# Source tag is cut on github.com/ryrobes/omarchy-quake.
+
+pkgname=omarchy-quake
+pkgver=1.6.2
+pkgrel=1
+pkgdesc="Quake 1 for Omarchy (vkQuake, shareware fetch, Tailscale deathmatch)"
+arch=('x86_64')
+url="https://github.com/ryrobes/omarchy-quake"
+license=('MIT' 'GPL-2.0-or-later')
+options=('!debug')
+depends=(
+  sdl3
+  vulkan-icd-loader
+  mpg123
+  libvorbis
+  flac
+  opus
+  libogg
+  python
+  libarchive
+  wl-clipboard
+  hicolor-icon-theme
+)
+makedepends=(
+  meson
+  ninja
+  git
+  patch
+  pkgconf
+  vulkan-headers
+  glslang
+  spirv-tools
+)
+optdepends=(
+  'vulkan-swrast: software rendering when there is no GPU'
+  'omarchy: menu stub, plugin enable, Hyprland session'
+  'tailscale: deathmatch over a tailnet'
+  '7zip: faster shareware extraction (bsdtar is the fallback)'
+  'qt6-multimedia-ffmpeg: animated video backdrop in the panel'
+)
+source=(
+  "$pkgname-$pkgver.tar.gz::https://github.com/ryrobes/omarchy-quake/archive/refs/tags/v$pkgver.tar.gz"
+  "vkQuake-1.35.0.tar.gz::https://github.com/Novum/vkQuake/archive/refs/tags/1.35.0.tar.gz"
+)
+sha256sums=(
+  '7b960b3dfe3ddb88291ffef049b60aad75655d456ad91b5a8059a92e962587c0'
+  '9f3a2bbf7ef22224c26a1a0d574562573fdaae2dc9758a98068617062d49c584'
+)
+
+prepare() {
+  rm -rf "$srcdir/$pkgname-$pkgver/vendor/vkQuake"
+  cp -a "$srcdir/vkQuake-1.35.0" "$srcdir/$pkgname-$pkgver/vendor/vkQuake"
+}
+
+build() {
+  cd "$srcdir/$pkgname-$pkgver"
+  bash scripts/build-engine.sh
+}
+
+package() {
+  cd "$srcdir/$pkgname-$pkgver"
+  DESTDIR="$pkgdir" PREFIX=/usr SKIP_BUILD=1 bash scripts/install.sh
+}

--- a/pkgbuilds/omarchy-quake/PKGBUILD
+++ b/pkgbuilds/omarchy-quake/PKGBUILD
@@ -17,6 +17,7 @@ depends=(
   libvorbis
   flac
   opus
+  opusfile
   libogg
   python
   libarchive

--- a/pkgbuilds/omarchy-quake/PKGBUILD
+++ b/pkgbuilds/omarchy-quake/PKGBUILD
@@ -3,10 +3,10 @@
 # Source tag is cut on github.com/ryrobes/omarchy-quake.
 
 pkgname=omarchy-quake
-pkgver=1.6.2
+pkgver=1.6.3
 pkgrel=1
 pkgdesc="Quake 1 for Omarchy (vkQuake, shareware fetch, Tailscale deathmatch)"
-arch=('x86_64')
+arch=('x86_64' 'aarch64')
 url="https://github.com/ryrobes/omarchy-quake"
 license=('MIT' 'GPL-2.0-or-later')
 options=('!debug')
@@ -38,14 +38,13 @@ optdepends=(
   'omarchy: menu stub, plugin enable, Hyprland session'
   'tailscale: deathmatch over a tailnet'
   '7zip: faster shareware extraction (bsdtar is the fallback)'
-  'qt6-multimedia-ffmpeg: animated video backdrop in the panel'
 )
 source=(
   "$pkgname-$pkgver.tar.gz::https://github.com/ryrobes/omarchy-quake/archive/refs/tags/v$pkgver.tar.gz"
   "vkQuake-1.35.0.tar.gz::https://github.com/Novum/vkQuake/archive/refs/tags/1.35.0.tar.gz"
 )
 sha256sums=(
-  '7b960b3dfe3ddb88291ffef049b60aad75655d456ad91b5a8059a92e962587c0'
+  '0cb3b685acc9ac4c14a5a0ae0f96b28dbe2e5260cf40e391801192f5e9a11eba'
   '9f3a2bbf7ef22224c26a1a0d574562573fdaae2dc9758a98068617062d49c584'
 )
 


### PR DESCRIPTION
Adds **omarchy-quake**: Quake 1 for Omarchy — vkQuake 1.35 (Vulkan, SDL3, native Wayland, Hyprland friendly) wrapped in an `omarchy-quake` launcher, a Quickshell panel plugin, and Hyprland window rules. First launch downloads the official shareware (~18MB); existing Steam/GOG PAKs and the 2021 re-release are auto-discovered. Deathmatch over Tailscale or LAN: hosting copies a one-line join command for the other machine.

Build notes:

- Two pinned GitHub tarballs (launcher tree + vkQuake 1.35.0), no git clone during build.
- Four small engine patches (NVIDIA Wayland quit crash, rcon fixes for the panel's map switching) applied with `patch(1)` and sentinel-checked.
- `package()` writes nothing to `$HOME`. The shell plugin ships as files under `/usr/share/omarchy-quake/plugin/`; the basecamp/omarchy install stub (companion PR) copies and enables it after pacman.
- MIT (launcher/plugin) + GPLv2 (vkQuake), both in `/usr/share/licenses/omarchy-quake/`.
- `x86_64` only for now; software rendering falls back to lavapipe via `vulkan-swrast` (optdepend).

Tested: `makepkg` from these exact sources, then `pacman -U` + plugin enable + play (single player and Tailscale deathmatch between two machines) on stock Omarchy 4. Fine to leave off the `fast` ring until it has soaked on edge.

Companion PR (menu stub + on-demand installer): basecamp/omarchy#7570

https://github.com/user-attachments/assets/b0f8762b-4743-4b93-bb86-36fdc6c1deb7
