### PR TITLE
Catch a package that has fallen behind Arch

### DIFF
--- a/.github/workflows/check-shadowed.yml
+++ b/.github/workflows/check-shadowed.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - 'pkgbuilds/**'
+      - 'helpers/**'
       - 'bin/check-shadowed'
       - '.github/workflows/check-shadowed.yml'
   schedule:
@@ -25,8 +26,11 @@ jobs:
       # get: Arch's own repositories for what it ships, and vercmp for which of
       # the two builds pacman calls newer.
       - name: Check for packages behind the official repositories
+        id: check
         run: |
           docker run --rm \
+            -e HOST_UID="$(id -u)" \
+            -e HOST_GID="$(id -g)" \
             -v "$PWD/bin:/workspace/bin:ro" \
             -v "$PWD/helpers:/workspace/helpers:ro" \
             -v "$PWD/pkgbuilds:/workspace/pkgbuilds:ro" \
@@ -39,19 +43,27 @@ jobs:
               printf "\n[multilib]\nInclude = /etc/pacman.d/mirrorlist\n" >> /etc/pacman.conf
               pacman -Sy --noconfirm
 
-              ./bin/check-shadowed
+              # The check sources every PKGBUILD, so it does not run as root: a
+              # pull request could otherwise replace vercmp in the container and
+              # have its own comparison come back equal.
+              groupadd -g "$HOST_GID" runner
+              useradd -m -u "$HOST_UID" -g "$HOST_GID" runner
+
+              runuser -u runner -- ./bin/check-shadowed
             '
 
-      # Only for the scheduled run: a pull request reports its own failure, but
-      # Arch moving ahead of a package here happens with nobody watching.
-      - name: Notify Basecamp on failure
-        if: failure() && github.event_name == 'schedule' && env.BASECAMP_CHATBOT_URL != ''
+      # Only when the check itself failed, and only on the schedule: a pull
+      # request reports its own result, while Arch pulling ahead of a package
+      # here happens with nobody watching. Without the step condition a mirror
+      # or Docker failure would announce a stale package that does not exist.
+      - name: Notify Basecamp
+        if: failure() && steps.check.outcome == 'failure' && github.event_name == 'schedule' && env.BASECAMP_CHATBOT_URL != ''
         env:
           BASECAMP_CHATBOT_URL: ${{ secrets.BASECAMP_CHATBOT_URL }}
         run: |
-          curl -s -o /dev/null \
+          curl -sS --fail -o /dev/null \
             -H "Content-Type: application/json" \
             -d "$(jq -n --arg content \
-              "🔴 <strong>A package is behind the official repositories</strong><br>Omarchy outranks Arch, so users are stuck on the older build.<br><a href=\"${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}\">View run</a>" \
+              "🔴 <strong>A package is behind the official repositories</strong><br>Omarchy outranks extra and multilib, so users are held on the older build.<br><a href=\"${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}\">View run</a>" \
               '{content: $content}')" \
             "$BASECAMP_CHATBOT_URL"

--- a/.github/workflows/check-shadowed.yml
+++ b/.github/workflows/check-shadowed.yml
@@ -1,0 +1,57 @@
+name: Check Shadowed Packages
+
+on:
+  pull_request:
+    paths:
+      - 'pkgbuilds/**'
+      - 'bin/check-shadowed'
+      - '.github/workflows/check-shadowed.yml'
+  schedule:
+    # Daily, off the hour to dodge the scheduling backlog at :00
+    - cron: '40 5 * * *'
+  workflow_dispatch:
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      # Runs in an Arch container because the comparison has to be the one users
+      # get: Arch's own repositories for what it ships, and vercmp for which of
+      # the two builds pacman calls newer.
+      - name: Check for packages behind the official repositories
+        run: |
+          docker run --rm \
+            -v "$PWD/bin:/workspace/bin:ro" \
+            -v "$PWD/helpers:/workspace/helpers:ro" \
+            -v "$PWD/pkgbuilds:/workspace/pkgbuilds:ro" \
+            -w /workspace \
+            archlinux:base-devel bash -lc '
+              set -euo pipefail
+
+              # multilib is disabled in the stock image, and multilib is where
+              # umu-launcher sat behind an older Omarchy build for three months.
+              printf "\n[multilib]\nInclude = /etc/pacman.d/mirrorlist\n" >> /etc/pacman.conf
+              pacman -Sy --noconfirm
+
+              ./bin/check-shadowed
+            '
+
+      # Only for the scheduled run: a pull request reports its own failure, but
+      # Arch moving ahead of a package here happens with nobody watching.
+      - name: Notify Basecamp on failure
+        if: failure() && github.event_name == 'schedule' && env.BASECAMP_CHATBOT_URL != ''
+        env:
+          BASECAMP_CHATBOT_URL: ${{ secrets.BASECAMP_CHATBOT_URL }}
+        run: |
+          curl -s -o /dev/null \
+            -H "Content-Type: application/json" \
+            -d "$(jq -n --arg content \
+              "🔴 <strong>A package is behind the official repositories</strong><br>Omarchy outranks Arch, so users are stuck on the older build.<br><a href=\"${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}\">View run</a>" \
+              '{content: $content}')" \
+            "$BASECAMP_CHATBOT_URL"

--- a/bin/check-shadowed
+++ b/bin/check-shadowed
@@ -1,0 +1,119 @@
+#!/bin/bash
+# Omarchy's pacman.conf orders [omarchy] above core, extra and multilib, and pacman
+# takes the first repository carrying a name without comparing versions across the
+# rest. So a package here that falls behind Arch is not dead weight: -Syu stops
+# offering the newer official build, and the -Syyuu in omarchy-refresh-pacman
+# downgrades to ours. Publishing a name Arch also ships is a promise to stay ahead
+# of it.
+set -euo pipefail
+
+BUILD_ROOT=$(realpath "${BASH_SOURCE[0]%/*}/..")
+source "$BUILD_ROOT/helpers/message-helpers.sh"
+source "$BUILD_ROOT/helpers/paths.sh"
+source "$BUILD_ROOT/helpers/package-metadata.sh"
+
+OFFICIAL_REPOS=(core extra multilib)
+
+print_header "Shadowed Package Check"
+
+for tool in pacman vercmp; do
+  command -v "$tool" >/dev/null || {
+    print_error "$tool is required; run this on Arch or in the archlinux container"
+    exit 1
+  }
+done
+
+# One listing per repository, rather than a pacman -Si per package. A repository
+# that lists nothing is a hole in the check rather than an empty repository, so
+# stop instead of quietly checking fewer names: multilib is disabled in a stock
+# Arch container, and multilib is exactly where umu-launcher was hiding.
+official=""
+for repo in "${OFFICIAL_REPOS[@]}"; do
+  # || true because pacman reports an unknown repository as a failure, and errexit
+  # would take the script out here with no output rather than reaching the check.
+  listing=$(pacman -Sl "$repo" 2>/dev/null | awk -v repo="$repo" '{print $2"\t"repo"\t"$3}' || true)
+
+  if [[ -z "$listing" ]]; then
+    print_error "[$repo] lists no packages; enable it and sync the databases first"
+    exit 1
+  fi
+
+  official+="$listing"$'\n'
+done
+
+# The PKGBUILD is the only place pkgname and epoch are recorded, and makepkg
+# sources it too, so read it the same way rather than parsing it by hand. That
+# means supplying the variables makepkg exports -- three PKGBUILDs here read
+# CARCH or SRCDEST at the top level and die under set -u without them, which is
+# how they would drop out of this check unnoticed.
+package_versions() {
+  (
+    set +eu
+    cd "$1" || exit 1
+
+    CARCH="${CARCH:-x86_64}"
+    SRCDEST="${SRCDEST:-$PWD}"
+    startdir="$PWD"
+    srcdir="$PWD/src"
+    pkgdir="$PWD/pkg"
+
+    # shellcheck disable=SC1091
+    source PKGBUILD 2>/dev/null
+
+    [[ -n "${pkgname:-}" && -n "${pkgver:-}" && -n "${pkgrel:-}" ]] || exit 1
+
+    local version="${pkgver}-${pkgrel}"
+    [[ -n "${epoch:-}" ]] && version="${epoch}:${version}"
+
+    local name
+    for name in "${pkgname[@]}"; do
+      echo "$name $version"
+    done
+  )
+}
+
+stale=0
+shadowed=0
+unreadable=0
+
+while IFS= read -r pkgdir; do
+  # A PKGBUILD that cannot be read is not a package that passes; say so, because
+  # skipping it quietly is what lets an unnoticed one drift behind Arch.
+  if ! versions=$(package_versions "$pkgdir"); then
+    print_error "$(basename "$pkgdir"): could not read pkgname and pkgver from its PKGBUILD"
+    unreadable=$((unreadable + 1))
+    continue
+  fi
+
+  while read -r name ours; do
+    [[ -n "$name" ]] || continue
+
+    entry=$(awk -F'\t' -v n="$name" '$1 == n { print $2"\t"$3; exit }' <<<"$official")
+    [[ -n "$entry" ]] || continue
+
+    repo="${entry%%$'\t'*}"
+    theirs="${entry##*$'\t'}"
+    shadowed=$((shadowed + 1))
+
+    if [[ "$(vercmp "$theirs" "$ours")" -gt 0 ]]; then
+      print_error "$name shadows $repo/$name with an older build: ours $ours, $repo $theirs"
+      stale=$((stale + 1))
+    else
+      print_info "$name shadows $repo/$name (ours $ours, $repo $theirs)"
+    fi
+  done <<<"$versions"
+done < <(package_dirs)
+
+echo
+if ((unreadable > 0)); then
+  print_error "$unreadable PKGBUILD(s) could not be read, so they went unchecked"
+  exit 1
+fi
+
+if ((stale > 0)); then
+  print_error "$stale of $shadowed shadowed package(s) are behind the official repositories"
+  echo "Either update them, or drop them so pacman resolves the official build."
+  exit 1
+fi
+
+print_success "$shadowed shadowed package(s), none behind the official repositories"

--- a/bin/check-shadowed
+++ b/bin/check-shadowed
@@ -1,10 +1,18 @@
 #!/bin/bash
-# Omarchy's pacman.conf orders [omarchy] above core, extra and multilib, and pacman
+# Omarchy's pacman.conf orders [omarchy] above [extra] and [multilib], and pacman
 # takes the first repository carrying a name without comparing versions across the
 # rest. So a package here that falls behind Arch is not dead weight: -Syu stops
 # offering the newer official build, and the -Syyuu in omarchy-refresh-pacman
 # downgrades to ours. Publishing a name Arch also ships is a promise to stay ahead
 # of it.
+#
+# [core] keeps its place above [omarchy], so a name Arch ships from core is
+# unreachable here rather than shadowed. That is worth reporting and not worth
+# failing over: users get Arch's build either way.
+#
+# This reads the PKGBUILDs, which is what a pull request changes. It says nothing
+# about what the mirror currently serves -- a build that never published leaves an
+# older package in the repository than the PKGBUILD here claims.
 set -euo pipefail
 
 BUILD_ROOT=$(realpath "${BASH_SOURCE[0]%/*}/..")
@@ -12,7 +20,10 @@ source "$BUILD_ROOT/helpers/message-helpers.sh"
 source "$BUILD_ROOT/helpers/paths.sh"
 source "$BUILD_ROOT/helpers/package-metadata.sh"
 
-OFFICIAL_REPOS=(core extra multilib)
+# Loaded in pacman's own resolution order, so the first repository carrying a name
+# is the one that answers for it.
+OUTRANKING_REPOS=(core)
+SHADOWED_REPOS=(extra multilib)
 
 print_header "Shadowed Package Check"
 
@@ -23,29 +34,39 @@ for tool in pacman vercmp; do
   }
 done
 
-# One listing per repository, rather than a pacman -Si per package. A repository
-# that lists nothing is a hole in the check rather than an empty repository, so
-# stop instead of quietly checking fewer names: multilib is disabled in a stock
-# Arch container, and multilib is exactly where umu-launcher was hiding.
-official=""
-for repo in "${OFFICIAL_REPOS[@]}"; do
-  # || true because pacman reports an unknown repository as a failure, and errexit
-  # would take the script out here with no output rather than reaching the check.
-  listing=$(pacman -Sl "$repo" 2>/dev/null | awk -v repo="$repo" '{print $2"\t"repo"\t"$3}' || true)
+declare -A official_repo official_version
 
-  if [[ -z "$listing" ]]; then
-    print_error "[$repo] lists no packages; enable it and sync the databases first"
+load_repo() {
+  local repo="$1" listing name version rest
+
+  # Not `|| true`: a listing that fails after emitting some rows would leave a
+  # partial repository behind and check fewer names while reporting success.
+  if ! listing=$(pacman -Sl "$repo" 2>/dev/null); then
+    print_error "[$repo] could not be listed; enable it and sync the package databases first"
     exit 1
   fi
 
-  official+="$listing"$'\n'
+  if [[ -z $listing ]]; then
+    print_error "[$repo] lists no packages; enable it and sync the package databases first"
+    exit 1
+  fi
+
+  while read -r _ name version rest; do
+    [[ -n $name ]] || continue
+    [[ -n ${official_repo[$name]:-} ]] && continue
+    official_repo[$name]="$repo"
+    official_version[$name]="$version"
+  done <<<"$listing"
+}
+
+for repo in "${OUTRANKING_REPOS[@]}" "${SHADOWED_REPOS[@]}"; do
+  load_repo "$repo"
 done
 
 # The PKGBUILD is the only place pkgname and epoch are recorded, and makepkg
 # sources it too, so read it the same way rather than parsing it by hand. That
-# means supplying the variables makepkg exports -- three PKGBUILDs here read
-# CARCH or SRCDEST at the top level and die under set -u without them, which is
-# how they would drop out of this check unnoticed.
+# means supplying the variables makepkg exports: three PKGBUILDs here read CARCH
+# or SRCDEST at the top level and would die under set -u without them.
 package_versions() {
   (
     set +eu
@@ -59,7 +80,11 @@ package_versions() {
 
     # shellcheck disable=SC1091
     source PKGBUILD 2>/dev/null
+    local status=$?
 
+    # A PKGBUILD that failed partway can leave a stale pkgver assigned from the
+    # lines that did run, so the status decides this rather than the variables.
+    [[ $status -eq 0 ]] || exit 1
     [[ -n "${pkgname:-}" && -n "${pkgver:-}" && -n "${pkgrel:-}" ]] || exit 1
 
     local version="${pkgver}-${pkgrel}"
@@ -72,27 +97,42 @@ package_versions() {
   )
 }
 
-stale=0
+examined=0
+names=0
 shadowed=0
+stale=0
+unreachable=0
 unreadable=0
 
 while IFS= read -r pkgdir; do
-  # A PKGBUILD that cannot be read is not a package that passes; say so, because
-  # skipping it quietly is what lets an unnoticed one drift behind Arch.
-  if ! versions=$(package_versions "$pkgdir"); then
-    print_error "$(basename "$pkgdir"): could not read pkgname and pkgver from its PKGBUILD"
+  package=$(basename "$pkgdir")
+
+  # Empty output counts as unreadable too: a PKGBUILD that calls exit at the top
+  # level ends the subshell successfully without ever naming a package, and
+  # skipping it quietly is how one drifts behind Arch unnoticed.
+  if ! versions=$(package_versions "$pkgdir") || [[ -z $versions ]]; then
+    print_error "$package: could not read pkgname and pkgver from its PKGBUILD"
     unreadable=$((unreadable + 1))
     continue
   fi
 
+  examined=$((examined + 1))
+
   while read -r name ours; do
-    [[ -n "$name" ]] || continue
+    [[ -n $name ]] || continue
+    names=$((names + 1))
 
-    entry=$(awk -F'\t' -v n="$name" '$1 == n { print $2"\t"$3; exit }' <<<"$official")
-    [[ -n "$entry" ]] || continue
+    repo="${official_repo[$name]:-}"
+    [[ -n $repo ]] || continue
 
-    repo="${entry%%$'\t'*}"
-    theirs="${entry##*$'\t'}"
+    theirs="${official_version[$name]}"
+
+    if [[ " ${OUTRANKING_REPOS[*]} " == *" $repo "* ]]; then
+      print_info "$name also exists in $repo, which outranks [omarchy]; ours is unreachable"
+      unreachable=$((unreachable + 1))
+      continue
+    fi
+
     shadowed=$((shadowed + 1))
 
     if [[ "$(vercmp "$theirs" "$ours")" -gt 0 ]]; then
@@ -105,8 +145,16 @@ while IFS= read -r pkgdir; do
 done < <(package_dirs)
 
 echo
+
 if ((unreadable > 0)); then
   print_error "$unreadable PKGBUILD(s) could not be read, so they went unchecked"
+  exit 1
+fi
+
+# Nothing examined means the tree was not found, not that the tree is clean. A
+# check that passes when it compared nothing is worse than no check at all.
+if ((examined == 0)); then
+  print_error "No packages were examined; expected PKGBUILDs under $PKGBUILDS_DIR"
   exit 1
 fi
 
@@ -116,4 +164,6 @@ if ((stale > 0)); then
   exit 1
 fi
 
-print_success "$shadowed shadowed package(s), none behind the official repositories"
+print_success "Checked $examined package(s) ($names names) against ${SHADOWED_REPOS[*]}: $shadowed shadowed, none behind"
+((unreachable > 0)) && print_info "$unreachable name(s) are unreachable behind ${OUTRANKING_REPOS[*]}"
+exit 0


### PR DESCRIPTION
Ordering `[omarchy]` above `[extra]` and `[multilib]` makes staleness a downgrade rather than dead weight. pacman stops at the first repository carrying a name and never compares versions across the rest:

| command | with an Omarchy build older than Arch's |
| --- | --- |
| `pacman -S <pkg>` | installs ours |
| `pacman -Syu` | "nothing to do" — the newer official build is never offered |
| `pacman -Syyuu` | downgrades to ours, and that is what `omarchy-refresh-pacman` runs |

`intel-lpmd`, `pinta` and `umu-launcher` sat three months behind Arch with nothing reporting it, which is why this is a check rather than a convention.

`bin/check-shadowed` compares every `pkgname` here against Arch's repositories with `vercmp`, pacman's own comparator, so the verdict is the one users' machines reach. `[core]` keeps its place above `[omarchy]`, so a name Arch ships from core is unreachable here rather than shadowed: reported, and not a failure.

A green run gets read as "nothing is behind Arch", so two things never pass quietly:

- **A repository that lists nothing is a hole in the check**, not an empty repository. multilib is disabled in the stock Arch image, and multilib is where `umu-launcher` hides.
- **A PKGBUILD that cannot be read is reported, not skipped.** One calling `exit` at the top level names no package at all; one that fails partway leaves whichever variables already ran, including a stale `pkgver`. Sourcing decides on the source status and on empty output, never on the surviving variables. The variables makepkg exports are supplied, since `1password`, `1password-beta` and `localsend` read `CARCH` or `SRCDEST` at the top level and would otherwise drop out under `set -u`.

The success line names what it compared — `Checked 112 package(s) (135 names) against extra multilib` — so a pass can be audited instead of trusted, and examining nothing is a failure rather than a clean result.

It runs on pull requests touching `pkgbuilds/` or `helpers/`, since `package_dirs` lives in helpers and enumerating nothing is the failure that matters, and daily, since Arch moves while nothing here changes. It runs as an unprivileged user because it sources every PKGBUILD, and one able to write `/usr/bin/vercmp` in the container would decide its own verdict. Basecamp hears about it only when the check itself failed, rather than on any Docker or mirror error.

This reads PKGBUILDs, which is what a pull request changes, and says nothing about what the mirror currently serves. #180 covers that.

🤖 Generated by Opus 5 in Claude Code. Reviewed by Codex XHigh.