### PR TITLE
Check what the mirror serves, not only what the tree says

### DIFF
--- a/.github/workflows/check-shadowed.yml
+++ b/.github/workflows/check-shadowed.yml
@@ -1,4 +1,4 @@
-name: Check Shadowed Packages
+name: Check Packages Against Arch
 
 on:
   pull_request:
@@ -6,6 +6,7 @@ on:
       - 'pkgbuilds/**'
       - 'helpers/**'
       - 'bin/check-shadowed'
+      - 'bin/check-published'
       - '.github/workflows/check-shadowed.yml'
   schedule:
     # Daily, off the hour to dodge the scheduling backlog at :00
@@ -65,5 +66,52 @@ jobs:
             -H "Content-Type: application/json" \
             -d "$(jq -n --arg content \
               "🔴 <strong>A package is behind the official repositories</strong><br>Omarchy outranks extra and multilib, so users are held on the older build.<br><a href=\"${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}\">View run</a>" \
+              '{content: $content}')" \
+            "$BASECAMP_CHATBOT_URL"
+
+  # The mirror is a separate question from the tree: a build that never published,
+  # or a package removed here but never removed from the repository, leaves
+  # [omarchy] serving something older than any PKGBUILD says. A pull request
+  # cannot change that, so this does not run on one.
+  published:
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Check what the mirror serves against the official repositories
+        id: check
+        run: |
+          docker run --rm \
+            -e HOST_UID="$(id -u)" \
+            -e HOST_GID="$(id -g)" \
+            -v "$PWD/bin:/workspace/bin:ro" \
+            -v "$PWD/helpers:/workspace/helpers:ro" \
+            -w /workspace \
+            archlinux:base-devel bash -lc '
+              set -euo pipefail
+
+              printf "\n[multilib]\nInclude = /etc/pacman.d/mirrorlist\n" >> /etc/pacman.conf
+              pacman -Sy --noconfirm
+
+              groupadd -g "$HOST_GID" runner
+              useradd -m -u "$HOST_UID" -g "$HOST_GID" runner
+
+              runuser -u runner -- ./bin/check-published
+            '
+
+      - name: Notify Basecamp
+        if: failure() && steps.check.outcome == 'failure' && github.event_name == 'schedule' && env.BASECAMP_CHATBOT_URL != ''
+        env:
+          BASECAMP_CHATBOT_URL: ${{ secrets.BASECAMP_CHATBOT_URL }}
+        run: |
+          curl -sS --fail -o /dev/null \
+            -H "Content-Type: application/json" \
+            -d "$(jq -n --arg content \
+              "🔴 <strong>The mirror is serving a package behind Arch</strong><br>Omarchy outranks extra and multilib, so users cannot upgrade past it.<br><a href=\"${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}\">View run</a>" \
               '{content: $content}')" \
             "$BASECAMP_CHATBOT_URL"

--- a/bin/check-published
+++ b/bin/check-published
@@ -1,0 +1,112 @@
+#!/bin/bash
+# What check-shadowed cannot see. That one reads the PKGBUILDs, which is what a
+# pull request changes; this reads what the mirror actually serves. A build that
+# never published, or a package removed from the tree but never removed from the
+# repository, leaves [omarchy] answering with something older than the PKGBUILD
+# claims -- and users resolve the mirror, not this git repository.
+#
+# x86_64 only. The comparison is against Arch's own core, extra and multilib, and
+# an aarch64 machine resolves Arch Linux ARM instead, whose versions differ.
+set -euo pipefail
+
+BUILD_ROOT=$(realpath "${BASH_SOURCE[0]%/*}/..")
+source "$BUILD_ROOT/helpers/message-helpers.sh"
+source "$BUILD_ROOT/helpers/official-packages.sh"
+
+MIRRORS=(edge stable)
+REPO_ARCH="${REPO_ARCH:-x86_64}"
+REPO_URL="${OMARCHY_REPO_URL:-https://pkgs.omarchy.org}"
+
+print_header "Published Package Check"
+
+for tool in curl tar pacman vercmp; do
+  command -v "$tool" >/dev/null || {
+    print_error "$tool is required; run this on Arch or in the archlinux container"
+    exit 1
+  }
+done
+
+load_official_packages || exit 1
+
+workdir=$(mktemp -d)
+trap 'rm -rf "$workdir"' EXIT
+
+checked=0
+shadowed=0
+stale=0
+unreachable=0
+
+for mirror in "${MIRRORS[@]}"; do
+  db="$workdir/$mirror.db.tar.zst"
+  url="$REPO_URL/$mirror/$REPO_ARCH/omarchy.db.tar.zst"
+
+  if ! curl -fsSL "$url" -o "$db"; then
+    print_error "Could not fetch $url"
+    exit 1
+  fi
+
+  # tar's status is checked rather than piped away: it exits non-zero when the
+  # archive holds no entry descriptions, and a pipeline would take that failure
+  # out of reach of the emptiness check below.
+  if ! descs=$(tar -xOf "$db" --wildcards '*/desc' 2>/dev/null); then
+    print_error "Could not read package entries from $url"
+    exit 1
+  fi
+
+  entries=$(awk '
+    /^%NAME%$/    { getline name; next }
+    /^%VERSION%$/ { getline version; if (name != "") { print name, version; name = "" }; next }
+  ' <<<"$descs")
+
+  # An unreadable database is not an empty repository. Reporting a clean mirror
+  # off a database we could not parse is the failure this check exists to avoid.
+  if [[ -z $entries ]]; then
+    print_error "Read no packages from $url"
+    exit 1
+  fi
+
+  print_info "$mirror: $(wc -l <<<"$entries") published package(s)"
+
+  while read -r name ours; do
+    [[ -n $name ]] || continue
+    checked=$((checked + 1))
+
+    repo="${official_repo[$name]:-}"
+    [[ -n $repo ]] || continue
+
+    theirs="${official_version[$name]}"
+
+    if repo_outranks_omarchy "$repo"; then
+      print_info "$mirror/$name is unreachable behind $repo/$name"
+      unreachable=$((unreachable + 1))
+      continue
+    fi
+
+    shadowed=$((shadowed + 1))
+
+    if [[ "$(vercmp "$theirs" "$ours")" -gt 0 ]]; then
+      print_error "$mirror serves $name $ours, behind $repo's $theirs"
+      stale=$((stale + 1))
+    else
+      print_info "$mirror/$name $ours (ahead of or level with $repo's $theirs)"
+    fi
+  done <<<"$entries"
+done
+
+echo
+
+if ((checked == 0)); then
+  print_error "No published packages were examined"
+  exit 1
+fi
+
+if ((stale > 0)); then
+  print_error "$stale published package(s) are behind the official repositories"
+  echo "Users resolve these from [omarchy] and cannot upgrade past them."
+  echo "Publish a build at or above Arch's version, or drop it with bin/repo remove-package."
+  exit 1
+fi
+
+print_success "Checked $checked published package(s) across ${MIRRORS[*]}: $shadowed shadowed, none behind"
+((unreachable > 0)) && print_info "$unreachable are unreachable behind ${OUTRANKING_REPOS[*]}"
+exit 0

--- a/bin/check-shadowed
+++ b/bin/check-shadowed
@@ -19,11 +19,7 @@ BUILD_ROOT=$(realpath "${BASH_SOURCE[0]%/*}/..")
 source "$BUILD_ROOT/helpers/message-helpers.sh"
 source "$BUILD_ROOT/helpers/paths.sh"
 source "$BUILD_ROOT/helpers/package-metadata.sh"
-
-# Loaded in pacman's own resolution order, so the first repository carrying a name
-# is the one that answers for it.
-OUTRANKING_REPOS=(core)
-SHADOWED_REPOS=(extra multilib)
+source "$BUILD_ROOT/helpers/official-packages.sh"
 
 print_header "Shadowed Package Check"
 
@@ -34,34 +30,7 @@ for tool in pacman vercmp; do
   }
 done
 
-declare -A official_repo official_version
-
-load_repo() {
-  local repo="$1" listing name version rest
-
-  # Not `|| true`: a listing that fails after emitting some rows would leave a
-  # partial repository behind and check fewer names while reporting success.
-  if ! listing=$(pacman -Sl "$repo" 2>/dev/null); then
-    print_error "[$repo] could not be listed; enable it and sync the package databases first"
-    exit 1
-  fi
-
-  if [[ -z $listing ]]; then
-    print_error "[$repo] lists no packages; enable it and sync the package databases first"
-    exit 1
-  fi
-
-  while read -r _ name version rest; do
-    [[ -n $name ]] || continue
-    [[ -n ${official_repo[$name]:-} ]] && continue
-    official_repo[$name]="$repo"
-    official_version[$name]="$version"
-  done <<<"$listing"
-}
-
-for repo in "${OUTRANKING_REPOS[@]}" "${SHADOWED_REPOS[@]}"; do
-  load_repo "$repo"
-done
+load_official_packages || exit 1
 
 # The PKGBUILD is the only place pkgname and epoch are recorded, and makepkg
 # sources it too, so read it the same way rather than parsing it by hand. That
@@ -127,7 +96,7 @@ while IFS= read -r pkgdir; do
 
     theirs="${official_version[$name]}"
 
-    if [[ " ${OUTRANKING_REPOS[*]} " == *" $repo "* ]]; then
+    if repo_outranks_omarchy "$repo"; then
       print_info "$name also exists in $repo, which outranks [omarchy]; ours is unreachable"
       unreachable=$((unreachable + 1))
       continue

--- a/helpers/official-packages.sh
+++ b/helpers/official-packages.sh
@@ -1,0 +1,41 @@
+# What Arch itself ships, in pacman's resolution order.
+#
+# Omarchy's pacman.conf keeps [core] above [omarchy] and puts [omarchy] above
+# [extra] and [multilib]. pacman takes the first repository carrying a name and
+# never compares versions across the rest, so a name Arch ships from core is
+# unreachable here, while a name from extra or multilib is one Omarchy answers
+# for -- and has to stay ahead of.
+
+OUTRANKING_REPOS=(core)
+SHADOWED_REPOS=(extra multilib)
+
+declare -A official_repo official_version
+
+load_official_packages() {
+  local repo listing name version
+
+  for repo in "${OUTRANKING_REPOS[@]}" "${SHADOWED_REPOS[@]}"; do
+    # Not `|| true`: a listing that fails after emitting some rows would leave a
+    # partial repository behind and check fewer names while reporting success.
+    if ! listing=$(pacman -Sl "$repo" 2>/dev/null); then
+      print_error "[$repo] could not be listed; enable it and sync the package databases first"
+      return 1
+    fi
+
+    if [[ -z $listing ]]; then
+      print_error "[$repo] lists no packages; enable it and sync the package databases first"
+      return 1
+    fi
+
+    while read -r _ name version _; do
+      [[ -n $name ]] || continue
+      [[ -n ${official_repo[$name]:-} ]] && continue
+      official_repo[$name]="$repo"
+      official_version[$name]="$version"
+    done <<<"$listing"
+  done
+}
+
+repo_outranks_omarchy() {
+  [[ " ${OUTRANKING_REPOS[*]} " == *" $1 "* ]]
+}


### PR DESCRIPTION
Stacked on #179.

`check-shadowed` reads PKGBUILDs, which is what a pull request changes — and that is the one question it cannot answer, because users resolve the mirror rather than this git repository. A build that never published, or a package deleted from the tree but never removed from the repository, leaves `[omarchy]` serving something older than any PKGBUILD claims, and a source-only check calls that clean.

Nine published packages are behind Arch right now:

| package | channel | published | official |
| --- | --- | --- | --- |
| `gpu-screen-recorder` | edge + stable | 5.12.3-2 | extra 6.0.0-1 |
| `intel-lpmd` | edge + stable | 0.1.0-2 | extra 0.1.0-4 |
| `pinta` | edge + stable | 3.1.2-1 | extra 3.1.2-2 |
| `umu-launcher` | edge + stable | 1.1.3-1.1 | multilib 1.4.4-1 |
| `opencode` | stable | 1.1.51-1 | extra 1.18.18-1 |

None of them has a PKGBUILD in this repository, so no check that reads the tree can see them. `opencode` is the one that makes the case: seventeen minor versions behind, on the channel most users are on. Once `[omarchy]` outranks `extra`, each is a package users cannot upgrade past, and `omarchy-refresh-pacman`'s `pacman -Syyuu` downgrades to it.

`bin/check-published` fetches each channel's `omarchy.db.tar.zst` over HTTP and compares every published version against Arch's repositories with `vercmp`. That needs no access to the repository host and no root — `pacman -Sy` requires root even against a private database path — so it runs as an unprivileged user in the same container as the other check.

The Arch-side lookup lives in `helpers/official-packages.sh` rather than being written twice, and carries the rule that `[core]` outranks `[omarchy]` for both checks.

Failing to read a channel is a failure, not a clean mirror: an unreachable host, an HTTP error, and an archive that parses to no package entries each stop the run rather than reporting nothing behind.

x86_64 only, deliberately. The comparison is against Arch's own `core`, `extra` and `multilib`, while an aarch64 machine resolves Arch Linux ARM, whose versions differ and would make every verdict meaningless.

It runs on the schedule and never on a pull request, since a pull request cannot change what the mirror serves.

🤖 Generated by Opus 5 in Claude Code. Reviewed by Codex XHigh.