### PR TITLE
omarchy-settings: ship session.slice.d/10-cpuweight.conf

### DIFF
--- a/pkgbuilds/omarchy-settings-dev/PKGBUILD
+++ b/pkgbuilds/omarchy-settings-dev/PKGBUILD
@@ -174,6 +174,9 @@ package() {
   # memory pressure costs one app scope instead of the compositor session.
   # Thresholds live in etc/systemd/oomd.conf.d/10-omarchy.conf.
   install -Dm644 default/systemd/user/app.slice.d/10-oomd.conf "$pkgdir/usr/lib/systemd/user/app.slice.d/10-oomd.conf"
+  # Weights session.slice (compositor, shell, PipeWire, portals) 10:1 over
+  # app.slice so saturating builds in terminals cannot stall compositor input.
+  install -Dm644 default/systemd/user/session.slice.d/10-cpuweight.conf "$pkgdir/usr/lib/systemd/user/session.slice.d/10-cpuweight.conf"
   install -Dm644 default/systemd/zram-generator.conf.d/90-omarchy.conf "$pkgdir/usr/lib/systemd/zram-generator.conf.d/90-omarchy.conf"
 
   # Same for applications/** — used by omarchy-refresh-applications,

--- a/pkgbuilds/omarchy-settings/PKGBUILD
+++ b/pkgbuilds/omarchy-settings/PKGBUILD
@@ -169,6 +169,9 @@ package() {
   # memory pressure costs one app scope instead of the compositor session.
   # Thresholds live in etc/systemd/oomd.conf.d/10-omarchy.conf.
   install -Dm644 default/systemd/user/app.slice.d/10-oomd.conf "$pkgdir/usr/lib/systemd/user/app.slice.d/10-oomd.conf"
+  # Weights session.slice (compositor, shell, PipeWire, portals) 10:1 over
+  # app.slice so saturating builds in terminals cannot stall compositor input.
+  install -Dm644 default/systemd/user/session.slice.d/10-cpuweight.conf "$pkgdir/usr/lib/systemd/user/session.slice.d/10-cpuweight.conf"
   install -Dm644 default/systemd/zram-generator.conf.d/90-omarchy.conf "$pkgdir/usr/lib/systemd/zram-generator.conf.d/90-omarchy.conf"
 
   # Same for applications/** — used by omarchy-refresh-applications,


### PR DESCRIPTION
Companion to basecamp/omarchy#7651, which adds `default/systemd/user/session.slice.d/10-cpuweight.conf` (`CPUWeight=1000` on the user session slice so saturating builds in app.slice cannot stall compositor input).

Installs it next to the existing `app.slice.d/10-oomd.conf` line in both `omarchy-settings` and `omarchy-settings-dev`.

**Depends on** the `_commit` bump that includes basecamp/omarchy#7651 — `install -Dm644` fails on a source tree without the file, so merge this in the same release as that bump, not before. The migration in #7651 is written to be safe either way (it applies the weight at runtime if the packaged drop-in is not there yet).