### PR TITLE
omasnap: update to 1.19.1

### DIFF
--- a/pkgbuilds/omasnap/PKGBUILD
+++ b/pkgbuilds/omasnap/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Tobi Lütke <tobi@lutke.com>
 
 pkgname=omasnap
-pkgver=1.17.1
+pkgver=1.19.0
 pkgrel=1
 pkgdesc="Native Wayland screenshot and annotation overlay for Hyprland"
 arch=('x86_64')
@@ -25,7 +25,7 @@ makedepends=(
 options=('!debug')
 
 source=("$pkgname-$pkgver.tar.gz::$url/archive/refs/tags/v$pkgver.tar.gz")
-sha256sums=('2ad60ec7f0b22bc868e3ac9c79ff3a283bf36a0d1f77f569d14b5282ac990165')
+sha256sums=('a43e723c6c77cd58fd703fbcec549fdfa7cc80064bac63567fcda7ae6c8a4dff')
 
 build() {
   cmake -S "$pkgname-$pkgver" -B build -G Ninja \

--- a/pkgbuilds/omasnap/PKGBUILD
+++ b/pkgbuilds/omasnap/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Tobi Lütke <tobi@lutke.com>
 
 pkgname=omasnap
-pkgver=1.16.0
+pkgver=1.17.1
 pkgrel=1
 pkgdesc="Native Wayland screenshot and annotation overlay for Hyprland"
 arch=('x86_64')
@@ -26,7 +26,7 @@ makedepends=(
 options=('!debug')
 
 source=("$pkgname-$pkgver.tar.gz::$url/archive/refs/tags/v$pkgver.tar.gz")
-sha256sums=('4a98d16d7c497408ef84ea5ae4a526b367264039f73649494fab118fb789fc48')
+sha256sums=('2ad60ec7f0b22bc868e3ac9c79ff3a283bf36a0d1f77f569d14b5282ac990165')
 
 build() {
   cmake -S "$pkgname-$pkgver" -B build -G Ninja \

--- a/pkgbuilds/omasnap/PKGBUILD
+++ b/pkgbuilds/omasnap/PKGBUILD
@@ -6,9 +6,8 @@ pkgrel=1
 pkgdesc="Native Wayland screenshot and annotation overlay for Hyprland"
 arch=('x86_64')
 url="https://github.com/tobi/omasnap"
-license=('MIT')
+license=('MIT' 'OFL-1.1')
 depends=(
-  'grim'
   'hyprland'
   'layer-shell-qt'
   'qt6-base'

--- a/pkgbuilds/omasnap/PKGBUILD
+++ b/pkgbuilds/omasnap/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Tobi Lütke <tobi@lutke.com>
 
 pkgname=omasnap
-pkgver=1.15.0
+pkgver=1.16.0
 pkgrel=1
 pkgdesc="Native Wayland screenshot and annotation overlay for Hyprland"
 arch=('x86_64')
@@ -26,7 +26,7 @@ makedepends=(
 options=('!debug')
 
 source=("$pkgname-$pkgver.tar.gz::$url/archive/refs/tags/v$pkgver.tar.gz")
-sha256sums=('3a87d475c4a12462ace139bb881882c342bc51da4c74b6606ff8cc21e74f6592')
+sha256sums=('4a98d16d7c497408ef84ea5ae4a526b367264039f73649494fab118fb789fc48')
 
 build() {
   cmake -S "$pkgname-$pkgver" -B build -G Ninja \

--- a/pkgbuilds/omasnap/PKGBUILD
+++ b/pkgbuilds/omasnap/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Tobi Lütke <tobi@lutke.com>
 
 pkgname=omasnap
-pkgver=1.19.0
+pkgver=1.19.1
 pkgrel=1
 pkgdesc="Native Wayland screenshot and annotation overlay for Hyprland"
 arch=('x86_64')
@@ -25,7 +25,7 @@ makedepends=(
 options=('!debug')
 
 source=("$pkgname-$pkgver.tar.gz::$url/archive/refs/tags/v$pkgver.tar.gz")
-sha256sums=('a43e723c6c77cd58fd703fbcec549fdfa7cc80064bac63567fcda7ae6c8a4dff')
+sha256sums=('ec68634cf336b8468c2f1ba405b1dcf6a24e1d5c2964bacc42bb8f2da335ed61')
 
 build() {
   cmake -S "$pkgname-$pkgver" -B build -G Ninja \


### PR DESCRIPTION
Updates omasnap to v1.19.1 (https://github.com/tobi/omasnap/releases/tag/v1.19.1).

- `pkgver` → 1.19.1
- `sha256sums` → hash of `https://github.com/tobi/omasnap/archive/refs/tags/v1.19.1.tar.gz`