### PR TITLE
Install the session.slice CPU weight drop-in into /usr/lib/systemd/user

### DIFF
--- a/pkgbuilds/omarchy-settings-dev/PKGBUILD
+++ b/pkgbuilds/omarchy-settings-dev/PKGBUILD
@@ -174,6 +174,9 @@ package() {
   # memory pressure costs one app scope instead of the compositor session.
   # Thresholds live in etc/systemd/oomd.conf.d/10-omarchy.conf.
   install -Dm644 default/systemd/user/app.slice.d/10-oomd.conf "$pkgdir/usr/lib/systemd/user/app.slice.d/10-oomd.conf"
+  # Weights the interactive tier over app.slice so saturating builds cannot
+  # starve compositor input; the default/** copy alone misses the search path.
+  install -Dm644 default/systemd/user/session.slice.d/10-cpuweight.conf "$pkgdir/usr/lib/systemd/user/session.slice.d/10-cpuweight.conf"
   install -Dm644 default/systemd/zram-generator.conf.d/90-omarchy.conf "$pkgdir/usr/lib/systemd/zram-generator.conf.d/90-omarchy.conf"
 
   # Same for applications/** — used by omarchy-refresh-applications,

--- a/pkgbuilds/omarchy-settings/PKGBUILD
+++ b/pkgbuilds/omarchy-settings/PKGBUILD
@@ -169,6 +169,9 @@ package() {
   # memory pressure costs one app scope instead of the compositor session.
   # Thresholds live in etc/systemd/oomd.conf.d/10-omarchy.conf.
   install -Dm644 default/systemd/user/app.slice.d/10-oomd.conf "$pkgdir/usr/lib/systemd/user/app.slice.d/10-oomd.conf"
+  # Weights the interactive tier over app.slice so saturating builds cannot
+  # starve compositor input; the default/** copy alone misses the search path.
+  install -Dm644 default/systemd/user/session.slice.d/10-cpuweight.conf "$pkgdir/usr/lib/systemd/user/session.slice.d/10-cpuweight.conf"
   install -Dm644 default/systemd/zram-generator.conf.d/90-omarchy.conf "$pkgdir/usr/lib/systemd/zram-generator.conf.d/90-omarchy.conf"
 
   # Same for applications/** — used by omarchy-refresh-applications,


### PR DESCRIPTION
basecamp/omarchy#7651 adds `default/systemd/user/session.slice.d/10-cpuweight.conf` — a `CPUWeight=1000` drop-in for the user manager's `session.slice` — along with the migration that applies it live, the docs entry and the tests. A file under `default/**` only reaches a machine through an explicit install line here, and there isn't one, so the generic `cp -a default/.` puts it at `/usr/share/omarchy/default/systemd/user/session.slice.d/` and nowhere the user manager reads. It would ship looking installed and do nothing — the shape of 2aa5c50, where `omarchy-crash-watch.service` reached the template tree and never the search path.

The gap is worse than a missing feature, because the migration hides it. A new install never runs that migration at all, since `omarchy-provision-user` marks every one complete on first install, so it gets neither the drop-in nor the runtime fallback. An existing install does get the weight from the fallback, but that lands in `/run/user/$UID/systemd/user.control/session.slice.d/50-CPUWeight.conf`, which does not outlive the user manager, and the completion marker then stops the migration ever running again. The setting would work until the next reboot and be gone for good afterwards, with nothing to say so.

Both recipes need the line. They carry identical `default/systemd/user` install sets today, and `test/shell.d/config-test.sh` only falls back to the dev PKGBUILD when the stable one is absent — so a dev recipe left behind is invisible to that suite while edge-channel machines get no drop-in, and edge is where this lands first.

That the destination is right is not taken on faith: the adjacent `app.slice.d/10-oomd.conf` line installs to the same shape, and the user manager reports `DropInPaths=/usr/lib/systemd/user/app.slice.d/10-oomd.conf` with its properties in effect. The same package already owns both that file and its template copy, so the second copy is the established pattern rather than a conflict.

**Merge order — this cannot land on its own.** Neither the pinned stable source (`_commit=f0020448`) nor today's `quattro` contains the drop-in, so `package()` aborts on `install: cannot stat 'default/systemd/user/session.slice.d/10-cpuweight.conf'`. basecamp/omarchy#7651 has to merge first, and the stable hunk belongs with the release commit that advances `_commit`/`pkgver`; bumping `pkgrel` before then would only trigger a build that fails. Draft until that ordering is available.

🤖 Generated by Opus 5 in Claude Code. Reviewed by Codex XHigh.
