### PR TITLE
fix(mise-bin): delay upstream releases for 24 hours

### DIFF
--- a/pkgbuilds/mise-bin/.omarchy/upstream.sh
+++ b/pkgbuilds/mise-bin/.omarchy/upstream.sh
@@ -4,10 +4,29 @@ set -euo pipefail
 repo="jdx/mise"
 release=$(curl -fsSL "https://api.github.com/repos/$repo/releases/latest")
 tag=$(jq -r '.tag_name // empty' <<<"$release")
+published_at=$(jq -r '.published_at // empty' <<<"$release")
 
 if [[ ! "$tag" =~ ^v([A-Za-z0-9._+]+)$ ]]; then
   echo "Latest mise release has an invalid tag: ${tag:-<empty>}" >&2
   exit 1
+fi
+
+if [[ -z "$published_at" ]] || ! published_epoch=$(date --date="$published_at" +%s); then
+  echo "Latest mise release has an invalid published_at: ${published_at:-<empty>}" >&2
+  exit 1
+fi
+
+# Keep a compromised mise release from reaching Omarchy before there has been
+# a full day for maintainers and the community to notice and pull it.
+minimum_release_age_seconds=$((24 * 60 * 60))
+now=$(date +%s)
+if (( now - published_epoch < minimum_release_age_seconds )); then
+  if [[ "${MISE_BIN_BYPASS_RELEASE_AGE:-}" == "1" ]]; then
+    echo "Bypassing mise release-age gate for $tag" >&2
+  else
+    echo '{}'
+    exit 0
+  fi
 fi
 
 pkgver=${BASH_REMATCH[1]}


### PR DESCRIPTION
## Summary

- Hold new mise releases for 24 hours from their GitHub `published_at` timestamp before OPR syncs them.
- Fail closed when the release timestamp is missing or invalid.
- Keep the policy package-specific for now so other OPR packages are unchanged.
- Provide an explicit, package-specific bypass for manually reviewed emergency updates.

## Why

This quarantine window gives critical bugs a day to surface and gives maintainers time to pull a bad release before it reaches Omarchy machines. It also limits immediate distribution if the mise maintainer account or release pipeline is compromised.

The check runs in `mise-bin`'s upstream hook before checksums are fetched or either release ring can build the package. Because upstream sync runs every six hours, a valid release should normally reach OPR 24–30 hours after publication.

## Emergency patches

Scheduled automation does not set the bypass. If a critical mise patch must ship inside the quarantine window, a maintainer can deliberately generate the update locally:

```bash
MISE_BIN_BYPASS_RELEASE_AGE=1 ./bin/sync-upstream mise-bin
```

The resulting PKGBUILD change can then be reviewed and merged through a normal manual PR, preserving an explicit human approval point.

## Testing

- Verified a 23:59:59-old release returns `{}` without fetching its checksums.
- Verified a release exactly 24 hours old is accepted with both architecture checksums.
- Verified the explicit emergency bypass accepts a younger release.
- Verified an invalid `published_at` fails closed.
- Ran `bash -n` and `git diff --check`.

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*