### PR TITLE
1password: build for aarch64

### DIFF
--- a/pkgbuilds/1password/.omarchy/README.md
+++ b/pkgbuilds/1password/.omarchy/README.md
@@ -1,0 +1,45 @@
+# 1Password - aarch64 Support
+
+## Overview
+
+`post-sync.sh` adds aarch64 (ARM64) support to the AUR `1password` PKGBUILD after each sync.
+
+This is implemented as a dynamic sync hook instead of a static patch because the aarch64 checksums include the current upstream version and need to be refreshed whenever AUR updates `_tarver`.
+
+## Background
+
+1Password officially provides ARM64 builds for Linux:
+
+- https://downloads.1password.com/linux/tar/stable/aarch64/
+
+The AUR PKGBUILD only supports x86_64.
+
+The sibling `1password-beta` package already carries this same hook; this brings the stable
+channel in line with it.
+
+## Changes Made
+
+1. Adds aarch64 to the arch array: `arch=('x86_64' 'aarch64')`
+2. Uses architecture-specific source arrays:
+   - x86_64: `.x64.tar.gz`
+   - aarch64: `.arm64.tar.gz`
+3. Keeps the AUR x86_64 checksums
+4. Downloads and calculates current aarch64 checksums during sync
+5. Uses `${_archdir}` for source directory names instead of hardcoded `.x64`
+6. Omarchy sync drops AUR-only `.SRCINFO` after rewriting the PKGBUILD
+7. Fails the sync (leaving the PKGBUILD untouched) if any of the declarations it rewrites
+   (`_tar=`, `arch=`, `source=`, `sha256sums=`) are missing or reformatted upstream, so a
+   partially rewritten recipe is never committed
+
+## Testing
+
+```bash
+bin/sync-aur 1password
+bin/repo build --arch aarch64 --package 1password
+```
+
+The aarch64 build should download from:
+
+```text
+https://downloads.1password.com/linux/tar/stable/aarch64/1password-<version>.arm64.tar.gz
+```

--- a/pkgbuilds/1password/.omarchy/post-sync.sh
+++ b/pkgbuilds/1password/.omarchy/post-sync.sh
@@ -1,0 +1,107 @@
+#!/bin/bash
+set -euo pipefail
+
+# Keep the AUR x86_64 checksums and add aarch64 sources. The aarch64
+# artifacts are signed by 1Password's validpgpkeys, so we skip checksums there
+# instead of baking version-specific hashes into Omarchy metadata.
+set +u
+CARCH=x86_64 source PKGBUILD
+set -u
+
+if declare -p sha256sums >/dev/null 2>&1 && [[ ${#sha256sums[@]} -ge 2 ]]; then
+  x86_sums=("${sha256sums[@]}")
+elif declare -p sha256sums_x86_64 >/dev/null 2>&1 && [[ ${#sha256sums_x86_64[@]} -ge 2 ]]; then
+  x86_sums=("${sha256sums_x86_64[@]}")
+else
+  echo "Unable to read x86_64 checksums from PKGBUILD" >&2
+  exit 1
+fi
+
+sha256_from_url() {
+  curl -fsSL "$1" | sha256sum | awk '{ print $1 }'
+}
+
+arm_url="https://downloads.1password.com/linux/tar/stable/aarch64/1password-${_tarver}.arm64.tar.gz"
+arm_tar_sum=$(sha256_from_url "$arm_url")
+arm_sig_sum=$(sha256_from_url "$arm_url.sig")
+
+emit_archdir() {
+  cat <<'EOF'
+case "${CARCH}" in
+    x86_64)
+        _archdir="x64"
+        ;;
+    aarch64)
+        _archdir="arm64"
+        ;;
+esac
+EOF
+}
+
+emit_sources() {
+  cat <<EOF
+source=()
+sha256sums=()
+source_x86_64=(https://downloads.1password.com/linux/tar/stable/x86_64/1password-\${_tarver}.x64.tar.gz{,.sig})
+source_aarch64=(https://downloads.1password.com/linux/tar/stable/aarch64/1password-\${_tarver}.arm64.tar.gz{,.sig})
+sha256sums_x86_64=('${x86_sums[0]}'
+                   '${x86_sums[1]}')
+sha256sums_aarch64=('$arm_tar_sum'
+                    '$arm_sig_sum')
+EOF
+}
+
+tmpfile=$(mktemp)
+skip_checksums=false
+matched_tar=false
+matched_arch=false
+matched_source=false
+matched_checksums=false
+
+while IFS= read -r line || [[ -n "$line" ]]; do
+  if [[ "$skip_checksums" == true ]]; then
+    [[ "$line" == ")" ]] && skip_checksums=false
+    continue
+  fi
+
+  case "$line" in
+    '_tar="1password-${_tarver}.x64.tar.gz"')
+      emit_archdir >> "$tmpfile"
+      matched_tar=true
+      ;;
+    "arch=('x86_64')")
+      echo "arch=('x86_64' 'aarch64')" >> "$tmpfile"
+      matched_arch=true
+      ;;
+    source=\(*)
+      emit_sources >> "$tmpfile"
+      matched_source=true
+      ;;
+    sha256sums=\(*)
+      [[ "$line" == *")" ]] || skip_checksums=true
+      matched_checksums=true
+      ;;
+    *)
+      line=${line//1password-\$\{_tarver\}.x64/1password-\$\{_tarver\}.\$\{_archdir\}}
+      printf '%s\n' "$line" >> "$tmpfile"
+      ;;
+  esac
+done < PKGBUILD
+
+# Refuse to install a partially rewritten PKGBUILD. If upstream reformats any
+# of the declarations matched above, fail loudly so the hook gets updated
+# instead of silently producing an x86_64-only or truncated recipe.
+missing=()
+[[ "$matched_tar" == true ]] || missing+=('_tar="1password-${_tarver}.x64.tar.gz"')
+[[ "$matched_arch" == true ]] || missing+=("arch=('x86_64')")
+[[ "$matched_source" == true ]] || missing+=("source=(")
+[[ "$matched_checksums" == true ]] || missing+=("sha256sums=(")
+[[ "$skip_checksums" == false ]] || missing+=("closing ')' of sha256sums")
+if [[ ${#missing[@]} -gt 0 ]]; then
+  rm -f "$tmpfile"
+  echo "post-sync.sh: upstream PKGBUILD no longer matches expected declarations:" >&2
+  printf '  %s\n' "${missing[@]}" >&2
+  exit 1
+fi
+
+mv "$tmpfile" PKGBUILD

--- a/pkgbuilds/1password/PKGBUILD
+++ b/pkgbuilds/1password/PKGBUILD
@@ -1,27 +1,38 @@
 pkgname=1password
 
 _tarver=8.12.34
-_tar="1password-${_tarver}.x64.tar.gz"
+case "${CARCH}" in
+    x86_64)
+        _archdir="x64"
+        ;;
+    aarch64)
+        _archdir="arm64"
+        ;;
+esac
 pkgver=${_tarver//-/_}
 pkgrel=34
 conflicts=('1password-beta' '1password-beta-bin')
 pkgdesc="Password manager and secure wallet"
-arch=('x86_64')
+arch=('x86_64' 'aarch64')
 url='https://1password.com'
 license=('LicenseRef-1Password-Proprietary')
 options=(!strip)
 install="1password.install"
-source=(https://downloads.1password.com/linux/tar/stable/${CARCH}/${_tar}{,.sig})
-sha256sums=('297784aa66770b645607a7f04c9ba2c4aebed4f46d21202487f521ba572b7b13'
-            'ec085bef60de748895d3c51a8208301ba2ac8fb47db99334539ba4bd1d3260d7'
-)
+source=()
+sha256sums=()
+source_x86_64=(https://downloads.1password.com/linux/tar/stable/x86_64/1password-${_tarver}.x64.tar.gz{,.sig})
+source_aarch64=(https://downloads.1password.com/linux/tar/stable/aarch64/1password-${_tarver}.arm64.tar.gz{,.sig})
+sha256sums_x86_64=('297784aa66770b645607a7f04c9ba2c4aebed4f46d21202487f521ba572b7b13'
+                   'ec085bef60de748895d3c51a8208301ba2ac8fb47db99334539ba4bd1d3260d7')
+sha256sums_aarch64=('ea5102363d6cf3442b96a7abd6743da8c1d261f56a628e1a3c183d84fa65fdcb'
+                    'f44db73fa44c3f68c3ab78a9cce140be9355de1dd9be4ce731c9d6597960c907')
 validpgpkeys=('3FEF9748469ADBE15DA7CA80AC2D62742012EA22')
 
 package() {
     depends=('hicolor-icon-theme' 'libgtk-3.so=0' 'nss' 'xdg-utils')
 
     # Go to source directory
-    cd "1password-${_tarver}.x64"
+    cd "1password-${_tarver}.${_archdir}"
 
     # Install icons
     resolutions=(32x32 64x64 256x256 512x512)
@@ -49,7 +60,7 @@ EOF" > ./com.1password.1Password.policy
     # Move package contents to /opt/1Password
     cd "${srcdir}"
     install -dm0755 "${pkgdir}"/opt
-    mv "1password-${_tarver}.x64" "${pkgdir}/opt/1Password"
+    mv "1password-${_tarver}.${_archdir}" "${pkgdir}/opt/1Password"
 
     # Cleanup un-needed files
     rm "${pkgdir}"/opt/1Password/com.1password.1Password.policy "${pkgdir}"/opt/1Password/com.1password.1Password.policy.tpl "${pkgdir}"/opt/1Password/install_biometrics_policy.sh


### PR DESCRIPTION
1Password publishes a Linux aarch64 build; only the PKGBUILD's x86_64 assumptions stopped it
being used.

**The sibling `1password-beta` package already solves exactly this**, so this reuses its
approach rather than inventing another: a `.omarchy/post-sync.sh` hook rather than a static
patch. As that package's own README puts it:

> implemented as a dynamic sync hook instead of a static patch because the aarch64 checksums
> include the current upstream version and need to be refreshed whenever AUR updates `_tarver`

The hook here is the beta one pointed at the stable channel. It:

- reads the x86_64 checksums out of the freshly synced PKGBUILD rather than storing them, so an
  upstream version bump carries through untouched
- downloads the aarch64 tarball and signature at sync time to compute their checksums
- emits `_archdir` (`x64` / `arm64`), adds `aarch64` to `arch=()`, and rewrites the source and
  checksum arrays per architecture
- rewrites the `.x64` references in `package()` to use `${_archdir}`
- fails the sync (leaving the PKGBUILD untouched) if any declaration it expects to rewrite is
  missing or reformatted upstream, so a partially rewritten recipe can never be committed

`1password-beta`'s README already listed the stable aarch64 URL alongside the beta one, so the
artifacts were known to exist — this just brings the stable channel in line.

## Testing

Ran the hook against a pristine synced copy of the current AUR PKGBUILD and confirmed the
rewrite:

```
arch=('x86_64' 'aarch64')
source_x86_64=(.../stable/x86_64/1password-${_tarver}.x64.tar.gz{,.sig})
source_aarch64=(.../stable/aarch64/1password-${_tarver}.arm64.tar.gz{,.sig})
cd "1password-${_tarver}.${_archdir}"
```

The checksum the hook fetched matches one computed by hand against
`https://downloads.1password.com/linux/tar/stable/aarch64/1password-8.12.34.arm64.tar.gz`.

Also exercised the fail-fast path by feeding the hook PKGBUILDs with each of `_tar=`, `arch=`,
`source=`, `sha256sums=` reformatted, and one with an unterminated checksum block: each case
exits 1 naming the missing declaration and leaves the input untouched.

Then built, installed and ran the result (originally at 8.12.32; rebased onto the 8.12.34 sync
with the hook re-run unchanged) on aarch64 (Arch Linux ARM, kernel
`7.2.0-1-aarch64-ARCH`):

```
/opt/1Password/1password: ELF 64-bit LSB pie executable, ARM aarch64
$ 1password --version
8.12.32
```

Every file in the built package was checked with `file(1)`: 16 ELF objects, all aarch64, no
x86-64.

x86_64 is unaffected — its source URL and checksums come through the hook unchanged, and
`_archdir` resolves to `x64` exactly as the current PKGBUILD hardcodes.

