### PR TITLE
chore(mise): bump to 2026.8.14

### DIFF
--- a/pkgbuilds/mise-bin/PKGBUILD
+++ b/pkgbuilds/mise-bin/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Jeff Dickey <releases@mise.jdx.dev>
 pkgname=mise-bin
-pkgver=2026.8.12
+pkgver=2026.8.14
 pkgrel=1
 pkgdesc="dev tools, env vars, task runner"
 arch=('x86_64' 'aarch64')
@@ -14,8 +14,8 @@ provides=('mise')
 conflicts=('mise')
 source_x86_64=("https://github.com/jdx/mise/releases/download/v${pkgver}/mise-v${pkgver}-linux-x64.tar.xz")
 source_aarch64=("https://github.com/jdx/mise/releases/download/v${pkgver}/mise-v${pkgver}-linux-arm64.tar.xz")
-sha256sums_x86_64=('da9d9c6f7a1b05f7d8ad85d08ed8bbf99aae144057b8709fdd9ef6b3b5b1a60e')
-sha256sums_aarch64=('fcbe68fa905fb7a5b203e4d4ef49bd1835313ff06105ba03d51a9a46021ea09d')
+sha256sums_x86_64=('80b49fa2dff282d3346524aec4466bbab536296ed5ba4d8c3b1b451022e94f56')
+sha256sums_aarch64=('81e1c5fa79c3d46cf93aac0ef9a5540bce9856634901a0db8301a656c370eb58')
 
 package() {
     install -Dm755 "${srcdir}/mise/bin/mise" "${pkgdir}/usr/bin/mise"


### PR DESCRIPTION
## Summary

- bump `mise-bin` from 2026.8.12 to 2026.8.14
- update the x86_64 and aarch64 checksums

## Why this is a manual bump

The `gemini-cli` installation bug exists only in mise 2026.8.13; 2026.8.12 is unaffected, and 2026.8.14 contains the fix.

Relying on OPR’s automatic upstream sync could temporarily promote 2026.8.13 while 2026.8.14 is still inside the configured 24-hour release-age window. This manual bump skips the broken release and moves directly from 2026.8.12 to 2026.8.14.

Upstream fix: https://github.com/jdx/mise/pull/12429

## Validation

- `bash -n pkgbuilds/mise-bin/PKGBUILD`
- `bin/repo build --dry-run --package mise-bin`
- downloaded and verified both release archives against their SHA-256 checksums

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*