### PR TITLE
Install the idle-inhibit user unit for omarchy#8452

### DIFF
--- a/pkgbuilds/omarchy-settings-dev/PKGBUILD
+++ b/pkgbuilds/omarchy-settings-dev/PKGBUILD
@@ -172,8 +172,13 @@ package() {
   install -Dm644 default/systemd/user/omarchy-crash-watch.service "$pkgdir/usr/lib/systemd/user/omarchy-crash-watch.service"
   # Owns org.freedesktop.ScreenSaver / PowerManagement so browsers can inhibit
   # idle over D-Bus (basecamp/omarchy#8452). The daemon binary ships from the
-  # omarchy package's bin/ glob; this unit is what systemd finds.
-  install -Dm644 default/systemd/user/omarchy-idle-inhibit.service "$pkgdir/usr/lib/systemd/user/omarchy-idle-inhibit.service"
+  # omarchy package's bin/ glob; this unit is what systemd finds. Gate on the
+  # file so a quattro tip before that merge does not abort package() on a
+  # missing source.
+  if [[ -f default/systemd/user/omarchy-idle-inhibit.service ]]; then
+    install -Dm644 default/systemd/user/omarchy-idle-inhibit.service \
+      "$pkgdir/usr/lib/systemd/user/omarchy-idle-inhibit.service"
+  fi
   # Marks app.slice (and only app.slice) as a systemd-oomd kill candidate, so
   # memory pressure costs one app scope instead of the compositor session.
   # Thresholds live in etc/systemd/oomd.conf.d/10-omarchy.conf.

--- a/pkgbuilds/omarchy-settings-dev/PKGBUILD
+++ b/pkgbuilds/omarchy-settings-dev/PKGBUILD
@@ -170,6 +170,10 @@ package() {
   install -Dm644 default/systemd/user/omarchy-tailscale-receive.service "$pkgdir/usr/lib/systemd/user/omarchy-tailscale-receive.service"
   install -Dm644 default/systemd/user/omarchy-fcitx5.service "$pkgdir/usr/lib/systemd/user/omarchy-fcitx5.service"
   install -Dm644 default/systemd/user/omarchy-crash-watch.service "$pkgdir/usr/lib/systemd/user/omarchy-crash-watch.service"
+  # Owns org.freedesktop.ScreenSaver / PowerManagement so browsers can inhibit
+  # idle over D-Bus (basecamp/omarchy#8452). The daemon binary ships from the
+  # omarchy package's bin/ glob; this unit is what systemd finds.
+  install -Dm644 default/systemd/user/omarchy-idle-inhibit.service "$pkgdir/usr/lib/systemd/user/omarchy-idle-inhibit.service"
   # Marks app.slice (and only app.slice) as a systemd-oomd kill candidate, so
   # memory pressure costs one app scope instead of the compositor session.
   # Thresholds live in etc/systemd/oomd.conf.d/10-omarchy.conf.

--- a/pkgbuilds/omarchy-settings/PKGBUILD
+++ b/pkgbuilds/omarchy-settings/PKGBUILD
@@ -165,6 +165,10 @@ package() {
   install -Dm644 default/systemd/user/omarchy-tailscale-receive.service "$pkgdir/usr/lib/systemd/user/omarchy-tailscale-receive.service"
   install -Dm644 default/systemd/user/omarchy-fcitx5.service "$pkgdir/usr/lib/systemd/user/omarchy-fcitx5.service"
   install -Dm644 default/systemd/user/omarchy-crash-watch.service "$pkgdir/usr/lib/systemd/user/omarchy-crash-watch.service"
+  # Owns org.freedesktop.ScreenSaver / PowerManagement so browsers can inhibit
+  # idle over D-Bus (basecamp/omarchy#8452). The daemon binary ships from the
+  # omarchy package's bin/ glob; this unit is what systemd finds.
+  install -Dm644 default/systemd/user/omarchy-idle-inhibit.service "$pkgdir/usr/lib/systemd/user/omarchy-idle-inhibit.service"
   # Marks app.slice (and only app.slice) as a systemd-oomd kill candidate, so
   # memory pressure costs one app scope instead of the compositor session.
   # Thresholds live in etc/systemd/oomd.conf.d/10-omarchy.conf.

--- a/pkgbuilds/omarchy-settings/PKGBUILD
+++ b/pkgbuilds/omarchy-settings/PKGBUILD
@@ -167,8 +167,13 @@ package() {
   install -Dm644 default/systemd/user/omarchy-crash-watch.service "$pkgdir/usr/lib/systemd/user/omarchy-crash-watch.service"
   # Owns org.freedesktop.ScreenSaver / PowerManagement so browsers can inhibit
   # idle over D-Bus (basecamp/omarchy#8452). The daemon binary ships from the
-  # omarchy package's bin/ glob; this unit is what systemd finds.
-  install -Dm644 default/systemd/user/omarchy-idle-inhibit.service "$pkgdir/usr/lib/systemd/user/omarchy-idle-inhibit.service"
+  # omarchy package's bin/ glob; this unit is what systemd finds. Gate on the
+  # file so a v4.0.1 pin (or a quattro tip before that merge) does not abort
+  # package() on a missing source.
+  if [[ -f default/systemd/user/omarchy-idle-inhibit.service ]]; then
+    install -Dm644 default/systemd/user/omarchy-idle-inhibit.service \
+      "$pkgdir/usr/lib/systemd/user/omarchy-idle-inhibit.service"
+  fi
   # Marks app.slice (and only app.slice) as a systemd-oomd kill candidate, so
   # memory pressure costs one app scope instead of the compositor session.
   # Thresholds live in etc/systemd/oomd.conf.d/10-omarchy.conf.


### PR DESCRIPTION
mise ~/.config/mise/config.toml tools: gh@2.98.0
## Summary
- Lockstep with [basecamp/omarchy#8452](https://github.com/basecamp/omarchy/pull/8452): `omarchy-idle-inhibit.service` lives under `default/systemd/user/` and has to land in `/usr/lib/systemd/user/` or systemd never finds it.
- Adds the `install -Dm644` line to both `omarchy-settings` and `omarchy-settings-dev`.
- The daemon and probe binaries do not need PKGBUILD lines; the `omarchy` package already glob-installs `bin/*`.

## Test plan
- [ ] Confirm `pkgbuilds/omarchy-settings/PKGBUILD` and `pkgbuilds/omarchy-settings-dev/PKGBUILD` both install `default/systemd/user/omarchy-idle-inhibit.service` to `/usr/lib/systemd/user/omarchy-idle-inhibit.service`
- [ ] Merge alongside omarchy#8452 so `ExecStart=/usr/bin/omarchy-idle-inhibit-daemon` has both the binary (omarchy package) and the unit (omarchy-settings)
