### PR TITLE
Install mise shell completions

### DIFF
--- a/pkgbuilds/mise-bin/PKGBUILD
+++ b/pkgbuilds/mise-bin/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Jeff Dickey <releases@mise.jdx.dev>
 pkgname=mise-bin
 pkgver=2026.8.14
-pkgrel=1
+pkgrel=2
 pkgdesc="dev tools, env vars, task runner"
 arch=('x86_64' 'aarch64')
 url="https://github.com/jdx/mise"
@@ -20,13 +20,26 @@ sha256sums_aarch64=('81e1c5fa79c3d46cf93aac0ef9a5540bce9856634901a0db8301a656c37
 package() {
     install -Dm755 "${srcdir}/mise/bin/mise" "${pkgdir}/usr/bin/mise"
 
+    # generate completions with the packaged binary
+    "${pkgdir}/usr/bin/mise" completion bash > "${srcdir}/mise.bash"
+    [[ -s "${srcdir}/mise.bash" ]] || return 1
+    install -Dm644 "${srcdir}/mise.bash" "${pkgdir}/usr/share/bash-completion/completions/mise"
+
+    "${pkgdir}/usr/bin/mise" completion zsh > "${srcdir}/_mise"
+    [[ -s "${srcdir}/_mise" ]] || return 1
+    install -Dm644 "${srcdir}/_mise" "${pkgdir}/usr/share/zsh/site-functions/_mise"
+
+    "${pkgdir}/usr/bin/mise" completion fish > "${srcdir}/mise.fish"
+    [[ -s "${srcdir}/mise.fish" ]] || return 1
+    install -Dm644 "${srcdir}/mise.fish" "${pkgdir}/usr/share/fish/vendor_completions.d/mise.fish"
+
     # disable mise self-update (managed by pacman)
     install -Dm644 /dev/null "${pkgdir}/usr/lib/mise/.disable-self-update"
 
     # man page
     install -Dm644 "${srcdir}/mise/man/man1/mise.1" "${pkgdir}/usr/share/man/man1/mise.1"
 
-    # fish completion (bash/zsh not included in pre-built tarball)
+    # fish activation
     install -Dm644 "${srcdir}/mise/share/fish/vendor_conf.d/mise-activate.fish" "${pkgdir}/usr/share/fish/vendor_conf.d/mise-activate.fish"
 
     # license


### PR DESCRIPTION
Closes #188.

This generates Bash, Zsh, and Fish completions with the staged `mise` binary during packaging, rejects empty generated output, and installs each file in the conventional shell-specific location. The existing Fish activation integration remains unchanged.

Verification:
- built `mise-bin` successfully with `makepkg` in `archlinux:base-devel`
- confirmed the resulting package contains all three completion files and the existing Fish activation file
- passed `omarchy-release self-test`, `omarchy-pkgs self-test`, and `sync-upstream self-test` in the Arch environment
- passed package-scoped edge and stable release dry-runs