### PR TITLE
Update asusctl to 6.4.0

### DIFF
--- a/pkgbuilds/asusctl/.omarchy/patches/6.4.0-github-source.patch
+++ b/pkgbuilds/asusctl/.omarchy/patches/6.4.0-github-source.patch
@@ -1,0 +1,18 @@
+diff --git a/PKGBUILD b/PKGBUILD
+index 55d0c22..8897aec 100644
+--- a/PKGBUILD
++++ b/PKGBUILD
+@@ -6,7 +6,7 @@ pkgname=(
+   asusctl
+   rog-control-center
+ )
+-pkgver=6.3.8
++pkgver=6.4.0
+ pkgrel=1
+ pkgdesc="A control daemon, tools, and a collection of crates for interacting with ASUS ROG laptops"
+ arch=('x86_64')
+@@ -28,2 +28,2 @@
+-source=("git+https://gitlab.com/asus-linux/asusctl.git#tag=$pkgver")
+-b2sums=('01269bc9fe63c1ce37568f9085c25dbcaaaa5cd9f51339d4c6904600d179ec826dace289d6e4e3501988fce5800da98e9cfa18b21c40da152d91c4f7fe821ffe')
++source=("git+https://github.com/opengamingcollective/asusctl.git#tag=$pkgver")
++b2sums=('0cfdc7f792fc6499cde9e4c9c6d82e484605e1b2878bb9f3a0e0696f5910b9ba7898f124fecd5fb3f39a0787f81e5163721606290099d757365dc3d6715a1bcf')

--- a/pkgbuilds/asusctl/PKGBUILD
+++ b/pkgbuilds/asusctl/PKGBUILD
@@ -6,8 +6,8 @@ pkgname=(
   asusctl
   rog-control-center
 )
-pkgver=6.3.8
-pkgrel=1
+pkgver=6.4.0
+pkgrel=1.1
 pkgdesc="A control daemon, tools, and a collection of crates for interacting with ASUS ROG laptops"
 arch=('x86_64')
 url="https://asus-linux.org"
@@ -25,8 +25,8 @@ makedepends=(
   seatd
   systemd
 )
-source=("git+https://gitlab.com/asus-linux/asusctl.git#tag=$pkgver")
-b2sums=('01269bc9fe63c1ce37568f9085c25dbcaaaa5cd9f51339d4c6904600d179ec826dace289d6e4e3501988fce5800da98e9cfa18b21c40da152d91c4f7fe821ffe')
+source=("git+https://github.com/opengamingcollective/asusctl.git#tag=$pkgver")
+b2sums=('0cfdc7f792fc6499cde9e4c9c6d82e484605e1b2878bb9f3a0e0696f5910b9ba7898f124fecd5fb3f39a0787f81e5163721606290099d757365dc3d6715a1bcf')
 
 prepare() {
   cd "${pkgbase}"


### PR DESCRIPTION
Closes #154.

This updates `asusctl` and `rog-control-center` from 6.3.8 to 6.4.0, follows the project source migration from GitLab to `opengamingcollective/asusctl` on GitHub, and refreshes the BLAKE2 checksum.

Because this is AUR-backed, the source/version change is also retained as an Omarchy patch so a later AUR sync cannot silently revert it. The checked-in package and a fresh raw-AUR-plus-overlay replay are byte-identical.

The version-bound overlay deliberately fails closed when the raw AUR recipe advances. That prevents this temporary upstream-ahead recipe from being silently transplanted onto a different release; once AUR catches up, the overlay should be reviewed and retired.

Verification:
- confirmed tag `6.4.0` resolves to upstream commit `e6c1469ccf2a745c6a1aff763852df90066c6baa`
- passed `makepkg --verifysource --holdver`
- built `asusctl`, `rog-control-center`, and the debug package successfully in `archlinux:base-devel`
- replayed the pinned AUR source through `bin/package-worktree`; `patched/` matches `current/`
- separately confirmed the overlay applies to the pinned raw recipe with `patch --dry-run --fuzz=0`
- passed `omarchy-pkgs self-test`, `omarchy-release self-test`, and the package-scoped edge release dry-run in the Arch environment

I could not reproduce the ROG Flow hardware startup path in the build environment, so the verification establishes the requested upstream version, source integrity, reproducible Omarchy overlay, and successful package build—not a hardware runtime claim.