### PR TITLE
Update aether to 4.29.6

### DIFF
--- a/pkgbuilds/aether/.omarchy/package.json
+++ b/pkgbuilds/aether/.omarchy/package.json
@@ -1,5 +1,5 @@
 {
   "source": "aur",
   "release_ring": "fast",
-  "upstream_commit": "2cc2e0ccfbc9a3da658236006992244cd68ba985"
+  "upstream_commit": "04592d5713f9c09ea2d81cf4b8476714d80014bc"
 }

--- a/pkgbuilds/aether/PKGBUILD
+++ b/pkgbuilds/aether/PKGBUILD
@@ -1,18 +1,18 @@
 # Maintainer: Bjarne Øverli <bjarne@oever.li>
 pkgname=aether
-pkgver=4.29.4
+pkgver=4.29.6
 pkgrel=1
 pkgdesc='Desktop theming application - extract colors from wallpapers and apply cohesive themes'
 arch=('x86_64' 'aarch64')
-url='https://github.com/bjarneo/aether'
+url='https://github.com/omacom-io/aether'
 license=('MIT')
 depends=('webkit2gtk-4.1' 'gtk3')
-source=("aether-${pkgver}.tar.gz::https://github.com/bjarneo/aether/archive/refs/tags/v${pkgver}.tar.gz")
-source_x86_64=("aether-linux-amd64-${pkgver}::https://github.com/bjarneo/aether/releases/download/v${pkgver}/aether-linux-amd64")
-source_aarch64=("aether-linux-arm64-${pkgver}::https://github.com/bjarneo/aether/releases/download/v${pkgver}/aether-linux-arm64")
-sha256sums=('ec46d524b9e562ead07ad0b6e85f5d16cc0c31e21cf5266d771dab95ef245d4e')
-sha256sums_x86_64=('d30a62378b344f998b29739b8f9700d5f79374eaa753b9268400c9a589e5cfa6')
-sha256sums_aarch64=('b012b12a2c7acf5372780418edfd7fd7c362fe57d9390555334a703873579be2')
+source=("aether-${pkgver}.tar.gz::https://github.com/omacom-io/aether/archive/refs/tags/v${pkgver}.tar.gz")
+source_x86_64=("aether-linux-amd64-${pkgver}::https://github.com/omacom-io/aether/releases/download/v${pkgver}/aether-linux-amd64")
+source_aarch64=("aether-linux-arm64-${pkgver}::https://github.com/omacom-io/aether/releases/download/v${pkgver}/aether-linux-arm64")
+sha256sums=('8b2e97283007c9eefda879e17c5fecb9d59fc90bf2160af93eeba57f11fcdb25')
+sha256sums_x86_64=('47b5afa4144b3a3cd7755524956ffe6b074ed5f2f90dadda23e424efeaf88790')
+sha256sums_aarch64=('52d1ffb201970ddb6205882a8e1c583cae63470d4180f4bc2fc6298dfb71ddd9')
 noextract=("aether-linux-amd64-${pkgver}" "aether-linux-arm64-${pkgver}")
 
 package() {


### PR DESCRIPTION
Synced from the AUR at `04592d5`.

Two upstream releases land together:

- **4.29.5** hardened the aether protocol imports, and moved the repository links from `bjarneo` to `omacom-io` — which is why `url` and every `source` line change here as well.
- **4.29.6** disables WebView GPU acceleration on Linux.

The packaging is untouched between the two: the AUR diff from 4.29.5 to 4.29.6 is only `pkgver` and the checksums. So taking AUR HEAD rather than pinning 4.29.5 costs nothing and carries the hardening either way.

`aether` is fast ring, so once merged this reaches **both** edge and stable through the normal `check-versions` → `auto-release` cycle, with no edge-to-stable migration needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)