### PR TITLE
Add omarket, the shareware marketplace CLI

### DIFF
--- a/pkgbuilds/omarket/.omarchy/package.json
+++ b/pkgbuilds/omarket/.omarchy/package.json
@@ -1,0 +1,12 @@
+{
+  "source": "local",
+  "min_release_age": "24h",
+  "upstream": {
+    "github": "aphexddb/omarket",
+    "checksums": "checksums.txt",
+    "assets": {
+      "x86_64": "omarket_linux_x86_64.tar.gz",
+      "aarch64": "omarket_linux_arm64.tar.gz"
+    }
+  }
+}

--- a/pkgbuilds/omarket/PKGBUILD
+++ b/pkgbuilds/omarket/PKGBUILD
@@ -1,0 +1,19 @@
+# Maintainer: Gardiner Allen <aphexddb@gmail.com>
+pkgname=omarket
+pkgver=0.4.0
+pkgrel=1
+pkgdesc="omarket CLI: browse, sell, and buy shareware from the omarket platform"
+arch=('x86_64' 'aarch64')
+url="https://omarket.dev"
+license=('MIT')
+options=('!strip' '!debug')
+source_x86_64=("${pkgname}-${pkgver}-x86_64.tar.gz::https://github.com/aphexddb/omarket/releases/download/v${pkgver}/omarket_linux_x86_64.tar.gz")
+source_aarch64=("${pkgname}-${pkgver}-aarch64.tar.gz::https://github.com/aphexddb/omarket/releases/download/v${pkgver}/omarket_linux_arm64.tar.gz")
+sha256sums_x86_64=('146f3ec7d66ca9bde2dd2f1974e0351374237fa07945a65c7f206d08c68d94e0')
+sha256sums_aarch64=('afb20d53793f9514e3fda558d5dff0240d85589ac9e769cfcaa9a800ddf74d07')
+
+package() {
+  install -Dm755 "${srcdir}/omarket" "${pkgdir}/usr/bin/omarket"
+  install -Dm644 "${srcdir}/LICENSE.md" "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"
+  install -Dm644 "${srcdir}/README.md" "${pkgdir}/usr/share/doc/${pkgname}/README.md"
+}


### PR DESCRIPTION
Adds [`omarket`](https://omarket.dev), a CLI to browse, sell, and buy shareware. Prebuilt Go binaries from GitHub releases (`aphexddb/omarket`), pinned at 0.4.0-1.

## Packaging

- Local package (`source: local`) for both `x86_64` and `aarch64`.
- `.omarchy/package.json` points `bin/sync-upstream` at the GitHub release feed (`checksums.txt` + version-free asset names), with `min_release_age: "24h"` so a bad release can be pulled before it reaches users.
- Source entries rename the archives to include `pkgver`. Upstream's asset names are deliberately version-free so `/releases/latest/download` works for the curl installer; without the rename every version would collide in `SRCDEST`.
- `options=('!strip' '!debug')` because goreleaser already strips with `-s -w`, and makepkg would otherwise try to split debug symbols out of a stripped binary.

Checksums are from the published archives, not placeholders.

## Verified

- `bin/repo build --package omarket` produced `omarket-0.4.0-1-x86_64.pkg.tar.zst`.
- Package contains `/usr/bin/omarket` (0755, stripped static Go binary), `/usr/share/licenses/omarket/LICENSE`, and `/usr/share/doc/omarket/README.md`.
- The packaged binary reports `0.4.0`.

aarch64 was not built locally: the edge ARM repo at `pkgs.omarchy.org/edge/aarch64` 404s during the builder image bootstrap (`omarchy.db`). The PKGBUILD and checksums cover it; the host can build it once that channel exists.

This is PKGBUILD-only. Publishing to `pkgs.omarchy.org` is for the repository host after merge (`bin/repo` `sign`/`promote`/`sync` live there, not on a contributor checkout).