### PR TITLE
Build Sunshine with CUDA support on x86_64

### DIFF
--- a/pkgbuilds/sunshine/.omarchy/patches/enable-cuda.patch
+++ b/pkgbuilds/sunshine/.omarchy/patches/enable-cuda.patch
@@ -1,0 +1,14 @@
+diff --git a/PKGBUILD b/PKGBUILD
+--- a/PKGBUILD
++++ b/PKGBUILD
+@@ -7 +7,5 @@
+-: "${_use_cuda:=detect}" # nvenc
++if [[ "$CARCH" == "x86_64" ]]; then
++  : "${_use_cuda:=true}" # nvenc
++else
++  : "${_use_cuda:=false}"
++fi
+@@ -70 +74,2 @@
+-)
++)
++makedepends_x86_64=('cuda')

--- a/pkgbuilds/sunshine/PKGBUILD
+++ b/pkgbuilds/sunshine/PKGBUILD
@@ -4,13 +4,17 @@
 ## options
 : "${_run_unit_tests:=false}"  # if set to true; unit tests will be executed post build; useful in CI
 : "${_support_headless_testing:=false}"
-: "${_use_cuda:=detect}" # nvenc
+if [[ "$CARCH" == "x86_64" ]]; then
+  : "${_use_cuda:=true}" # nvenc
+else
+  : "${_use_cuda:=false}"
+fi
 
 : "${_commit:=14ffa6fdaa53f7b51512be2b3d24f3939695403c}"
 
 pkgname='sunshine'
 pkgver=2026.516.143833
-pkgrel=4
+pkgrel=4.1
 pkgdesc="Self-hosted game stream host for Moonlight"
 arch=('x86_64' 'aarch64')
 url=https://app.lizardbyte.dev/Sunshine
@@ -68,6 +72,7 @@ makedepends=(
   'python-jinja'  # required by the glad OpenGL/EGL loader generator
   'shaderc'
 )
+makedepends_x86_64=('cuda')
 
 checkdepends=(
   'gcovr'


### PR DESCRIPTION
## Summary

- enable Sunshine CUDA support by default on x86_64
- add the CUDA toolkit as an x86_64-only build dependency
- keep aarch64 builds CUDA-free and otherwise unchanged
- preserve the correction as an Omarchy overlay across future AUR syncs

This fixes the packaging path behind basecamp/omarchy#7752: generic builders previously had no CUDA package installed, so the upstream `detect` default disabled the CUDA translation unit and NVIDIA users fell back to software encoding.

## Verification

- exact AUR commit `3c38fe4064f8c8a49b9d2420468c29f812074d3f`
- overlay applies with `--fuzz=0`
- `bin/sync-aur sunshine` is idempotent
- x86_64 evaluation emits `_use_cuda=true`, `makedepends_x86_64 = cuda`, and the CUDA optdepend
- aarch64 evaluation emits `_use_cuda=false` with no generic CUDA dependency
- `makepkg --verifysource` passed for the pinned source and both existing backports

A complete CUDA compilation is left to the repository x86_64 builder; the current toolkit is a 4.71 GiB installed dependency. The source, architecture selection, dependency metadata, and overlay regeneration gates all pass locally.
