### PR TITLE
Update Omatrack to 1.5.5

### DIFF
--- a/pkgbuilds/omatrack/PKGBUILD
+++ b/pkgbuilds/omatrack/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: David Heinemeier Hansson <david@hey.com>
 
 pkgname=omatrack
-pkgver=1.2.0
+pkgver=1.5.5
 pkgrel=1
 pkgdesc="Cross-format motorsport telemetry analysis workstation"
 arch=('x86_64' 'aarch64')
@@ -11,9 +11,9 @@ depends=('qt6-base' 'qt6-declarative' 'mpv' 'libyaml' 'gcc-libs' 'glibc' 'hicolo
 makedepends=('cmake' 'ninja' 'rust')
 options=('!debug' '!lto')
 
-_commit=ebe7f4f6b05845a85a2b713f889e676442fd0e82
+_commit=5b0feebd01aa7617c625187c816d20ba128cc908
 source=("omatrack-$_commit.tar.gz::$url/archive/$_commit.tar.gz")
-sha256sums=('8e6c62de5f8c98239a84abe9696c83f1155bef12004ee2c028bd99d64b8263a4')
+sha256sums=('ef765c721098a43a6934b8dc753504b0a634b911a09e5b5b8b9caccd3b4ce94f')
 
 prepare() {
   cd "omatrack-$_commit/third_party/motorsport-telemetry"


### PR DESCRIPTION
Updates the Omarchy-owned Omatrack package from 1.2.0 to the latest stable 1.5.5 release.

The package remains bound to the upstream annotated-tag target commit and exact commit-archive checksum. Existing architecture, dependency, build, install, license, and channel policy remain unchanged.

Verification:

- GitHub reports the annotated `v1.5.5` tag signature as valid; target commit `5b0feebd01aa7617c625187c816d20ba128cc908`
- exact 222,098,635-byte source archive verified as `sha256:ef765c721098a43a6934b8dc753504b0a634b911a09e5b5b8b9caccd3b4ce94f`
- clean native x86_64 Arch package build passed
- 19/19 upstream CTest cases passed, including lint, Rust, CLI, and headless contracts
- package metadata, installed desktop/icon/metainfo/license paths, and `omatrack --version` passed
- all four repository self-test suites passed
- edge build selection and stable promotion-only dry runs passed

The produced x86_64 package was `omatrack-1.5.5-1-x86_64.pkg.tar.zst`, `sha256:1cfd62930744b846f45d9149c26209bd5155e0476abc6a69302e8d8719e3f1a2`.

Native aarch64 compilation was not available and is not claimed.