### PR TITLE
omarchy-settings: name the release Omarchy Quattro

### DIFF
--- a/pkgbuilds/omarchy-settings-dev/PKGBUILD
+++ b/pkgbuilds/omarchy-settings-dev/PKGBUILD
@@ -4,6 +4,9 @@ pkgver=4.0.0.r847.g4de185b
 pkgrel=1
 _pkgver_base=4.0.0
 _pkgver_base_tag=v3.8.2
+# Release codename shown in os-release PRETTY_NAME / VERSION and /etc/issue.
+# Bump this with the major version (Quattro is 4.x).
+_codename='Quattro'
 pkgdesc='Omarchy user defaults, /etc/skel content, fonts, plymouth theme, and support helpers (quattro branch tip)'
 arch=('any')
 url='https://github.com/basecamp/omarchy'
@@ -204,17 +207,25 @@ package() {
     "$pkgdir/usr/share/omarchy/etc-overrides/dot.bashrc"
   cat >"$pkgdir/usr/share/omarchy/etc-overrides/os-release" <<EOF
 NAME="Omarchy"
-PRETTY_NAME="Omarchy"
+PRETTY_NAME="Omarchy ${_codename}"
+VERSION="$pkgver (${_codename})"
 ID=omarchy
 ID_LIKE=arch
 BUILD_ID="$pkgver"
 VERSION_ID="$pkgver"
+VERSION_CODENAME="${_codename,,}"
 ANSI_COLOR="38;2;158;206;106"
 HOME_URL="https://omarchy.org/"
 DOCUMENTATION_URL="https://learn.omacom.io/2/the-omarchy-manual"
 SUPPORT_URL="https://discord.gg/tXFUdasqhY"
 BUG_REPORT_URL="https://github.com/basecamp/omarchy/issues"
 LOGO=omarchy
+EOF
+  # filesystem owns /etc/issue (Arch's "\S{PRETTY_NAME} \r (\l)" placeholder).
+  # Ship a named banner next to os-release and copy it in post_install.
+  cat >"$pkgdir/usr/share/omarchy/etc-overrides/issue" <<EOF
+Omarchy ${_codename} \\r (\\l)
+
 EOF
   for path in "${_etc_override_paths[@]}"; do
     case "$path" in

--- a/pkgbuilds/omarchy-settings-dev/omarchy-settings-dev.install
+++ b/pkgbuilds/omarchy-settings-dev/omarchy-settings-dev.install
@@ -7,14 +7,15 @@ _etc_overrides_apply() {
   install -d /etc/plymouth /etc/security /etc/skel
 
   # NOTE: these cp -f's are intentionally destructive on every install/upgrade.
-  # Users who customize /etc/os-release, /etc/plymouth/plymouthd.conf (theme
-  # switch), /etc/cups/cups-browsed.conf, /etc/nsswitch.conf,
+  # Users who customize /etc/os-release, /etc/issue, /etc/plymouth/plymouthd.conf
+  # (theme switch), /etc/cups/cups-browsed.conf, /etc/nsswitch.conf,
   # /etc/security/faillock.conf, or /etc/skel/.bashrc WILL have their changes
   # reset to Omarchy defaults each time omarchy-settings-dev is upgraded. This is
   # the trade-off of routing upstream-owned paths through etc-overrides instead
   # of pacman backup=().
   rm -f /etc/os-release
   cp -f /usr/share/omarchy/etc-overrides/os-release              /etc/os-release
+  cp -f /usr/share/omarchy/etc-overrides/issue                   /etc/issue
   cp -f /usr/share/omarchy/etc-overrides/security-faillock.conf  /etc/security/faillock.conf
   cp -f /usr/share/omarchy/etc-overrides/nsswitch.conf           /etc/nsswitch.conf
   if [[ -f /etc/cups/cups-browsed.conf ]]; then
@@ -23,7 +24,7 @@ _etc_overrides_apply() {
   fi
   cp -f /usr/share/omarchy/etc-overrides/plymouth-plymouthd.conf /etc/plymouth/plymouthd.conf
   cp -f /usr/share/omarchy/etc-overrides/dot.bashrc              /etc/skel/.bashrc
-  chmod 0644 /etc/os-release /etc/security/faillock.conf /etc/nsswitch.conf \
+  chmod 0644 /etc/os-release /etc/issue /etc/security/faillock.conf /etc/nsswitch.conf \
              /etc/plymouth/plymouthd.conf /etc/skel/.bashrc
   if [[ -f /etc/cups/cups-browsed.conf ]]; then
     chmod 0644 /etc/cups/cups-browsed.conf

--- a/pkgbuilds/omarchy-settings/PKGBUILD
+++ b/pkgbuilds/omarchy-settings/PKGBUILD
@@ -14,6 +14,9 @@ _tag='v4.0.1'
 _commit='13f18b2cb7286fb54f87daf571a031aa6af3d8f0'
 pkgver=4.0.1
 pkgrel=1
+# Release codename shown in os-release PRETTY_NAME / VERSION and /etc/issue.
+# Bump this with the major version (Quattro is 4.x).
+_codename='Quattro'
 pkgdesc='Omarchy user defaults, /etc/skel content, fonts, plymouth theme, and support helpers'
 arch=('any')
 url='https://github.com/basecamp/omarchy'
@@ -199,17 +202,25 @@ package() {
     "$pkgdir/usr/share/omarchy/etc-overrides/dot.bashrc"
   cat >"$pkgdir/usr/share/omarchy/etc-overrides/os-release" <<EOF
 NAME="Omarchy"
-PRETTY_NAME="Omarchy"
+PRETTY_NAME="Omarchy ${_codename}"
+VERSION="$pkgver (${_codename})"
 ID=omarchy
 ID_LIKE=arch
 BUILD_ID="$pkgver"
 VERSION_ID="$pkgver"
+VERSION_CODENAME="${_codename,,}"
 ANSI_COLOR="38;2;158;206;106"
 HOME_URL="https://omarchy.org/"
 DOCUMENTATION_URL="https://learn.omacom.io/2/the-omarchy-manual"
 SUPPORT_URL="https://discord.gg/tXFUdasqhY"
 BUG_REPORT_URL="https://github.com/basecamp/omarchy/issues"
 LOGO=omarchy
+EOF
+  # filesystem owns /etc/issue (Arch's "\S{PRETTY_NAME} \r (\l)" placeholder).
+  # Ship a named banner next to os-release and copy it in post_install.
+  cat >"$pkgdir/usr/share/omarchy/etc-overrides/issue" <<EOF
+Omarchy ${_codename} \\r (\\l)
+
 EOF
   for path in "${_etc_override_paths[@]}"; do
     case "$path" in

--- a/pkgbuilds/omarchy-settings/omarchy-settings.install
+++ b/pkgbuilds/omarchy-settings/omarchy-settings.install
@@ -7,14 +7,15 @@ _etc_overrides_apply() {
   install -d /etc/plymouth /etc/security /etc/skel
 
   # NOTE: these cp -f's are intentionally destructive on every install/upgrade.
-  # Users who customize /etc/os-release, /etc/plymouth/plymouthd.conf (theme
-  # switch), /etc/cups/cups-browsed.conf, /etc/nsswitch.conf,
+  # Users who customize /etc/os-release, /etc/issue, /etc/plymouth/plymouthd.conf
+  # (theme switch), /etc/cups/cups-browsed.conf, /etc/nsswitch.conf,
   # /etc/security/faillock.conf, or /etc/skel/.bashrc WILL have their changes
   # reset to Omarchy defaults each time omarchy-settings is upgraded. This is
   # the trade-off of routing upstream-owned paths through etc-overrides instead
   # of pacman backup=().
   rm -f /etc/os-release
   cp -f /usr/share/omarchy/etc-overrides/os-release              /etc/os-release
+  cp -f /usr/share/omarchy/etc-overrides/issue                   /etc/issue
   cp -f /usr/share/omarchy/etc-overrides/security-faillock.conf  /etc/security/faillock.conf
   cp -f /usr/share/omarchy/etc-overrides/nsswitch.conf           /etc/nsswitch.conf
   if [[ -f /etc/cups/cups-browsed.conf ]]; then
@@ -23,7 +24,7 @@ _etc_overrides_apply() {
   fi
   cp -f /usr/share/omarchy/etc-overrides/plymouth-plymouthd.conf /etc/plymouth/plymouthd.conf
   cp -f /usr/share/omarchy/etc-overrides/dot.bashrc              /etc/skel/.bashrc
-  chmod 0644 /etc/os-release /etc/security/faillock.conf /etc/nsswitch.conf \
+  chmod 0644 /etc/os-release /etc/issue /etc/security/faillock.conf /etc/nsswitch.conf \
              /etc/plymouth/plymouthd.conf /etc/skel/.bashrc
   if [[ -f /etc/cups/cups-browsed.conf ]]; then
     chmod 0644 /etc/cups/cups-browsed.conf


### PR DESCRIPTION
`cat /etc/issue` currently prints Arch's `\S{PRETTY_NAME} \r (\l)` placeholder, and `os-release` `PRETTY_NAME` is just `"Omarchy"` — no release identity.

4.x is already called Quattro (the `quattro` branch, `omarchy-upgrade-to-quattro`, migrations, community). This gives that name to the files getty, `hostnamectl`, and fastfetch actually show.

## Changes

In both `omarchy-settings` and `omarchy-settings-dev`:

- `PRETTY_NAME="Omarchy Quattro"`
- `VERSION="$pkgver (Quattro)"` and `VERSION_CODENAME=quattro`
- Ship `/usr/share/omarchy/etc-overrides/issue` as `Omarchy Quattro \r (\l)` and copy it over Arch's `/etc/issue` in `post_install` / `post_upgrade` (same etc-overrides pattern as `os-release`; `filesystem` owns the live path)

Codename is `_codename='Quattro'` at the top of each PKGBUILD so the next major version is one assignment.

After this ships:

```
$ cat /etc/issue
Omarchy Quattro \r (\l)

$ hostnamectl | grep Operating
Operating System: Omarchy Quattro
```

The `\r` / `\l` escapes stay for agetty (kernel release and tty), matching Ubuntu/Debian style.