### PR TITLE
Stage CUPS authorization as settings override

### DIFF
--- a/pkgbuilds/omarchy-settings-dev/PKGBUILD
+++ b/pkgbuilds/omarchy-settings-dev/PKGBUILD
@@ -38,7 +38,8 @@ makedepends=(
 # backup=() is pacman's hook for protecting user edits to package-owned files
 # on upgrade. Only the paths the package actually installs into /etc qualify.
 # The etc-overrides set (faillock.conf, nsswitch.conf, cups-browsed.conf,
-# plymouthd.conf, /etc/skel/.bashrc) ships at /usr/share/omarchy/etc-overrides/
+# cups-files.conf, plymouthd.conf, /etc/skel/.bashrc) ships at
+# /usr/share/omarchy/etc-overrides/
 # and is cp -f'd by post_install — those paths are unowned by pacman and the
 # scriptlet WILL clobber user edits on each upgrade (documented limitation).
 backup=(
@@ -90,6 +91,7 @@ _etc_override_paths=(
   'etc/security/faillock.conf'
   'etc/nsswitch.conf'
   'etc/cups/cups-browsed.conf'
+  'etc/cups/cups-files.conf'
   'etc/plymouth/plymouthd.conf'
 )
 
@@ -224,6 +226,8 @@ EOF
         mv "$pkgdir/$path" "$pkgdir/usr/share/omarchy/etc-overrides/nsswitch.conf" ;;
       'etc/cups/cups-browsed.conf')
         mv "$pkgdir/$path" "$pkgdir/usr/share/omarchy/etc-overrides/cups-cups-browsed.conf" ;;
+      'etc/cups/cups-files.conf')
+        [[ ! -f $pkgdir/$path ]] || mv "$pkgdir/$path" "$pkgdir/usr/share/omarchy/etc-overrides/cups-cups-files.conf" ;;
       'etc/plymouth/plymouthd.conf')
         mv "$pkgdir/$path" "$pkgdir/usr/share/omarchy/etc-overrides/plymouth-plymouthd.conf" ;;
     esac

--- a/pkgbuilds/omarchy-settings-dev/omarchy-settings-dev.install
+++ b/pkgbuilds/omarchy-settings-dev/omarchy-settings-dev.install
@@ -8,7 +8,7 @@ _etc_overrides_apply() {
 
   # NOTE: these cp -f's are intentionally destructive on every install/upgrade.
   # Users who customize /etc/os-release, /etc/plymouth/plymouthd.conf (theme
-  # switch), /etc/cups/cups-browsed.conf, /etc/nsswitch.conf,
+  # switch), /etc/cups/cups-browsed.conf, /etc/cups/cups-files.conf, /etc/nsswitch.conf,
   # /etc/security/faillock.conf, or /etc/skel/.bashrc WILL have their changes
   # reset to Omarchy defaults each time omarchy-settings-dev is upgraded. This is
   # the trade-off of routing upstream-owned paths through etc-overrides instead
@@ -20,6 +20,10 @@ _etc_overrides_apply() {
   if [[ -f /etc/cups/cups-browsed.conf ]]; then
     install -d /etc/cups
     cp -f /usr/share/omarchy/etc-overrides/cups-cups-browsed.conf /etc/cups/cups-browsed.conf
+  fi
+  if [[ -f /etc/cups/cups-files.conf && -f /usr/share/omarchy/etc-overrides/cups-cups-files.conf ]]; then
+    systemd-sysusers /etc/sysusers.d/omarchy-cups-browsed.conf
+    install -m 0640 -o root -g cups /usr/share/omarchy/etc-overrides/cups-cups-files.conf /etc/cups/cups-files.conf
   fi
   cp -f /usr/share/omarchy/etc-overrides/plymouth-plymouthd.conf /etc/plymouth/plymouthd.conf
   cp -f /usr/share/omarchy/etc-overrides/dot.bashrc              /etc/skel/.bashrc

--- a/pkgbuilds/omarchy-settings/PKGBUILD
+++ b/pkgbuilds/omarchy-settings/PKGBUILD
@@ -47,7 +47,8 @@ makedepends=(
 # backup=() is pacman's hook for protecting user edits to package-owned files
 # on upgrade. Only the paths the package actually installs into /etc qualify.
 # The etc-overrides set (faillock.conf, nsswitch.conf, cups-browsed.conf,
-# plymouthd.conf, /etc/skel/.bashrc) ships at /usr/share/omarchy/etc-overrides/
+# cups-files.conf, plymouthd.conf, /etc/skel/.bashrc) ships at
+# /usr/share/omarchy/etc-overrides/
 # and is cp -f'd by post_install — those paths are unowned by pacman and the
 # scriptlet WILL clobber user edits on each upgrade (documented limitation).
 backup=(
@@ -99,6 +100,7 @@ _etc_override_paths=(
   'etc/security/faillock.conf'
   'etc/nsswitch.conf'
   'etc/cups/cups-browsed.conf'
+  'etc/cups/cups-files.conf'
   'etc/plymouth/plymouthd.conf'
 )
 
@@ -219,6 +221,8 @@ EOF
         mv "$pkgdir/$path" "$pkgdir/usr/share/omarchy/etc-overrides/nsswitch.conf" ;;
       'etc/cups/cups-browsed.conf')
         mv "$pkgdir/$path" "$pkgdir/usr/share/omarchy/etc-overrides/cups-cups-browsed.conf" ;;
+      'etc/cups/cups-files.conf')
+        [[ ! -f $pkgdir/$path ]] || mv "$pkgdir/$path" "$pkgdir/usr/share/omarchy/etc-overrides/cups-cups-files.conf" ;;
       'etc/plymouth/plymouthd.conf')
         mv "$pkgdir/$path" "$pkgdir/usr/share/omarchy/etc-overrides/plymouth-plymouthd.conf" ;;
     esac

--- a/pkgbuilds/omarchy-settings/omarchy-settings.install
+++ b/pkgbuilds/omarchy-settings/omarchy-settings.install
@@ -8,7 +8,7 @@ _etc_overrides_apply() {
 
   # NOTE: these cp -f's are intentionally destructive on every install/upgrade.
   # Users who customize /etc/os-release, /etc/plymouth/plymouthd.conf (theme
-  # switch), /etc/cups/cups-browsed.conf, /etc/nsswitch.conf,
+  # switch), /etc/cups/cups-browsed.conf, /etc/cups/cups-files.conf, /etc/nsswitch.conf,
   # /etc/security/faillock.conf, or /etc/skel/.bashrc WILL have their changes
   # reset to Omarchy defaults each time omarchy-settings is upgraded. This is
   # the trade-off of routing upstream-owned paths through etc-overrides instead
@@ -20,6 +20,10 @@ _etc_overrides_apply() {
   if [[ -f /etc/cups/cups-browsed.conf ]]; then
     install -d /etc/cups
     cp -f /usr/share/omarchy/etc-overrides/cups-cups-browsed.conf /etc/cups/cups-browsed.conf
+  fi
+  if [[ -f /etc/cups/cups-files.conf && -f /usr/share/omarchy/etc-overrides/cups-cups-files.conf ]]; then
+    systemd-sysusers /etc/sysusers.d/omarchy-cups-browsed.conf
+    install -m 0640 -o root -g cups /usr/share/omarchy/etc-overrides/cups-cups-files.conf /etc/cups/cups-files.conf
   fi
   cp -f /usr/share/omarchy/etc-overrides/plymouth-plymouthd.conf /etc/plymouth/plymouthd.conf
   cp -f /usr/share/omarchy/etc-overrides/dot.bashrc              /etc/skel/.bashrc


### PR DESCRIPTION
Stage the Omarchy CUPS authorization policy under `/usr/share/omarchy/etc-overrides` and apply it from the settings package.

The source-file and install-time guards keep current stable/dev builds working until basecamp/omarchy#8627 lands.

Validated by building both the pre-change stable source and the revised local source; the revised package installs `/etc/cups/cups-files.conf` as `0640 root:cups` without a `.pacnew`.