### PR TITLE
Package Omarchy static system state

### DIFF
--- a/pkgbuilds/omarchy-settings-dev/PKGBUILD
+++ b/pkgbuilds/omarchy-settings-dev/PKGBUILD
@@ -64,11 +64,8 @@ backup=(
   'etc/systemd/system.conf.d/20-omarchy-nofile.conf'
   'etc/systemd/user.conf.d/20-omarchy-nofile.conf'
   'etc/systemd/oomd.conf.d/10-omarchy.conf'
-  'etc/systemd/zram-generator.conf'
   'etc/sddm.conf.d/10-theme.conf'
   'etc/sddm.conf.d/10-wayland.conf'
-  'etc/udev/rules.d/99-omarchy-power-profile.rules'
-  'etc/udev/rules.d/99-omarchy-wifi-powersave.rules'
 )
 
 optdepends=(
@@ -78,7 +75,7 @@ optdepends=(
   'limine: Bootloader the shipped /etc/mkinitcpio.conf.d/ and /etc/limine-entry-tool.d/ drop-ins are for'
   'limine-mkinitcpio-hook: Picks up the shipped /etc/mkinitcpio.conf.d/omarchy_hooks.conf'
   'limine-snapper-sync: Boot-entry sync for snapper snapshots'
-  'zram-generator: Reads the shipped /etc/systemd/zram-generator.conf to create the compressed swap device'
+  'zram-generator: Reads the shipped vendor drop-in to create the compressed swap device'
   'snapper: Used with the shipped /etc/snapper/config-templates/omarchy template'
 )
 
@@ -307,12 +304,15 @@ EOF
   # System font.
   install -Dm644 default/fonts/omarchy/omarchy.ttf "$pkgdir/usr/share/fonts/omarchy/omarchy.ttf"
 
-  # systemd system-sleep hook (lazy-unmounts gvfsd-fuse mounts before
-  # suspend/hibernate). The script also ships under /usr/share/omarchy/default
-  # via the default/** copy above; we additionally install it to the live
-  # systemd path so the hook fires.
+  # systemd system-sleep hooks. The scripts also ship under
+  # /usr/share/omarchy/default via the default/** copy above; these live copies
+  # are package-owned so runtime commands never seed static files into /usr.
   install -Dm755 default/systemd/system-sleep/unmount-fuse \
     "$pkgdir/usr/lib/systemd/system-sleep/unmount-fuse"
+  install -Dm755 default/systemd/system-sleep/keyboard-backlight \
+    "$pkgdir/usr/lib/systemd/system-sleep/omarchy-keyboard-backlight"
+  install -Dm755 default/systemd/system-sleep/force-igpu \
+    "$pkgdir/usr/lib/systemd/system-sleep/omarchy-force-igpu"
 
   # Branding assets (logos, icons).
   install -Dm644 logo.txt "$pkgdir/usr/share/omarchy/logo.txt"

--- a/pkgbuilds/omarchy-settings-dev/omarchy-settings-dev.install
+++ b/pkgbuilds/omarchy-settings-dev/omarchy-settings-dev.install
@@ -6,15 +6,19 @@ _etc_overrides_apply() {
   # installed or pacman will preserve its packaged file as a noisy .pacnew.
   install -d /etc/plymouth /etc/security /etc/skel
 
-  # NOTE: these cp -f's are intentionally destructive on every install/upgrade.
-  # Users who customize /etc/os-release, /etc/plymouth/plymouthd.conf (theme
-  # switch), /etc/cups/cups-browsed.conf, /etc/cups/cups-files.conf, /etc/nsswitch.conf,
+  # NOTE: these overrides are intentionally destructive on every install/upgrade.
+  # Users who customize the /etc/os-release selector,
+  # /etc/plymouth/plymouthd.conf (theme switch),
+  # /etc/cups/cups-browsed.conf, /etc/cups/cups-files.conf, /etc/nsswitch.conf,
   # /etc/security/faillock.conf, or /etc/skel/.bashrc WILL have their changes
   # reset to Omarchy defaults each time omarchy-settings-dev is upgraded. This is
   # the trade-off of routing upstream-owned paths through etc-overrides instead
   # of pacman backup=().
+  # /etc/os-release is conventionally a generated selector rather than a
+  # package-owned path. Keep the selected content package-owned, and use a
+  # relative link so it remains valid inside chroots and initrds.
   rm -f /etc/os-release
-  cp -f /usr/share/omarchy/etc-overrides/os-release              /etc/os-release
+  ln -s ../usr/share/omarchy/etc-overrides/os-release            /etc/os-release
   cp -f /usr/share/omarchy/etc-overrides/security-faillock.conf  /etc/security/faillock.conf
   cp -f /usr/share/omarchy/etc-overrides/nsswitch.conf           /etc/nsswitch.conf
   if [[ -f /etc/cups/cups-browsed.conf ]]; then
@@ -27,7 +31,7 @@ _etc_overrides_apply() {
   fi
   cp -f /usr/share/omarchy/etc-overrides/plymouth-plymouthd.conf /etc/plymouth/plymouthd.conf
   cp -f /usr/share/omarchy/etc-overrides/dot.bashrc              /etc/skel/.bashrc
-  chmod 0644 /etc/os-release /etc/security/faillock.conf /etc/nsswitch.conf \
+  chmod 0644 /etc/security/faillock.conf /etc/nsswitch.conf \
              /etc/plymouth/plymouthd.conf /etc/skel/.bashrc
   if [[ -f /etc/cups/cups-browsed.conf ]]; then
     chmod 0644 /etc/cups/cups-browsed.conf
@@ -40,4 +44,14 @@ post_install() {
 
 post_upgrade() {
   _etc_overrides_apply
+}
+
+post_remove() {
+  # Restore the standard Arch selector if removing this package left its exact
+  # Omarchy link dangling. During a stable/dev replacement, the incoming
+  # package either still supplies the target or replaces this link afterward.
+  if [[ -L /etc/os-release && ! -e /etc/os-release && $(readlink /etc/os-release) == "../usr/share/omarchy/etc-overrides/os-release" ]]; then
+    rm -f /etc/os-release
+    ln -s ../usr/lib/os-release /etc/os-release
+  fi
 }

--- a/pkgbuilds/omarchy-settings/PKGBUILD
+++ b/pkgbuilds/omarchy-settings/PKGBUILD
@@ -73,11 +73,8 @@ backup=(
   'etc/systemd/system.conf.d/20-omarchy-nofile.conf'
   'etc/systemd/user.conf.d/20-omarchy-nofile.conf'
   'etc/systemd/oomd.conf.d/10-omarchy.conf'
-  'etc/systemd/zram-generator.conf'
   'etc/sddm.conf.d/10-theme.conf'
   'etc/sddm.conf.d/10-wayland.conf'
-  'etc/udev/rules.d/99-omarchy-power-profile.rules'
-  'etc/udev/rules.d/99-omarchy-wifi-powersave.rules'
 )
 
 optdepends=(
@@ -87,7 +84,7 @@ optdepends=(
   'limine: Bootloader the shipped /etc/mkinitcpio.conf.d/ and /etc/limine-entry-tool.d/ drop-ins are for'
   'limine-mkinitcpio-hook: Picks up the shipped /etc/mkinitcpio.conf.d/omarchy_hooks.conf'
   'limine-snapper-sync: Boot-entry sync for snapper snapshots'
-  'zram-generator: Reads the shipped /etc/systemd/zram-generator.conf to create the compressed swap device'
+  'zram-generator: Reads the shipped vendor drop-in to create the compressed swap device'
   'snapper: Used with the shipped /etc/snapper/config-templates/omarchy template'
 )
 
@@ -302,12 +299,15 @@ EOF
   # System font.
   install -Dm644 default/fonts/omarchy/omarchy.ttf "$pkgdir/usr/share/fonts/omarchy/omarchy.ttf"
 
-  # systemd system-sleep hook (lazy-unmounts gvfsd-fuse mounts before
-  # suspend/hibernate). The script also ships under /usr/share/omarchy/default
-  # via the default/** copy above; we additionally install it to the live
-  # systemd path so the hook fires.
+  # systemd system-sleep hooks. The scripts also ship under
+  # /usr/share/omarchy/default via the default/** copy above; these live copies
+  # are package-owned so runtime commands never seed static files into /usr.
   install -Dm755 default/systemd/system-sleep/unmount-fuse \
     "$pkgdir/usr/lib/systemd/system-sleep/unmount-fuse"
+  install -Dm755 default/systemd/system-sleep/keyboard-backlight \
+    "$pkgdir/usr/lib/systemd/system-sleep/omarchy-keyboard-backlight"
+  install -Dm755 default/systemd/system-sleep/force-igpu \
+    "$pkgdir/usr/lib/systemd/system-sleep/omarchy-force-igpu"
 
   # Branding assets (logos, icons).
   install -Dm644 logo.txt "$pkgdir/usr/share/omarchy/logo.txt"

--- a/pkgbuilds/omarchy-settings/omarchy-settings.install
+++ b/pkgbuilds/omarchy-settings/omarchy-settings.install
@@ -6,15 +6,19 @@ _etc_overrides_apply() {
   # installed or pacman will preserve its packaged file as a noisy .pacnew.
   install -d /etc/plymouth /etc/security /etc/skel
 
-  # NOTE: these cp -f's are intentionally destructive on every install/upgrade.
-  # Users who customize /etc/os-release, /etc/plymouth/plymouthd.conf (theme
-  # switch), /etc/cups/cups-browsed.conf, /etc/cups/cups-files.conf, /etc/nsswitch.conf,
+  # NOTE: these overrides are intentionally destructive on every install/upgrade.
+  # Users who customize the /etc/os-release selector,
+  # /etc/plymouth/plymouthd.conf (theme switch),
+  # /etc/cups/cups-browsed.conf, /etc/cups/cups-files.conf, /etc/nsswitch.conf,
   # /etc/security/faillock.conf, or /etc/skel/.bashrc WILL have their changes
   # reset to Omarchy defaults each time omarchy-settings is upgraded. This is
   # the trade-off of routing upstream-owned paths through etc-overrides instead
   # of pacman backup=().
+  # /etc/os-release is conventionally a generated selector rather than a
+  # package-owned path. Keep the selected content package-owned, and use a
+  # relative link so it remains valid inside chroots and initrds.
   rm -f /etc/os-release
-  cp -f /usr/share/omarchy/etc-overrides/os-release              /etc/os-release
+  ln -s ../usr/share/omarchy/etc-overrides/os-release            /etc/os-release
   cp -f /usr/share/omarchy/etc-overrides/security-faillock.conf  /etc/security/faillock.conf
   cp -f /usr/share/omarchy/etc-overrides/nsswitch.conf           /etc/nsswitch.conf
   if [[ -f /etc/cups/cups-browsed.conf ]]; then
@@ -27,7 +31,7 @@ _etc_overrides_apply() {
   fi
   cp -f /usr/share/omarchy/etc-overrides/plymouth-plymouthd.conf /etc/plymouth/plymouthd.conf
   cp -f /usr/share/omarchy/etc-overrides/dot.bashrc              /etc/skel/.bashrc
-  chmod 0644 /etc/os-release /etc/security/faillock.conf /etc/nsswitch.conf \
+  chmod 0644 /etc/security/faillock.conf /etc/nsswitch.conf \
              /etc/plymouth/plymouthd.conf /etc/skel/.bashrc
   if [[ -f /etc/cups/cups-browsed.conf ]]; then
     chmod 0644 /etc/cups/cups-browsed.conf
@@ -40,4 +44,14 @@ post_install() {
 
 post_upgrade() {
   _etc_overrides_apply
+}
+
+post_remove() {
+  # Restore the standard Arch selector if removing this package left its exact
+  # Omarchy link dangling. During a stable/dev replacement, the incoming
+  # package either still supplies the target or replaces this link afterward.
+  if [[ -L /etc/os-release && ! -e /etc/os-release && $(readlink /etc/os-release) == "../usr/share/omarchy/etc-overrides/os-release" ]]; then
+    rm -f /etc/os-release
+    ln -s ../usr/lib/os-release /etc/os-release
+  fi
 }


### PR DESCRIPTION
## Depends on

- omacom/omarchy#9070 must merge first. That PR removes automatic file-conflict recovery and makes the 3.x to Quattro upgrader the only ownership-adoption boundary.

## What changed

- Both stable and development `omarchy-settings` packages now own the static keyboard-backlight and guarded force-iGPU system-sleep hooks.
- The force-iGPU hook is inert unless `/etc/omarchy/force-igpu` exists and `supergfxctl` is installed, so packaging the hook does not enable the feature.
- `/etc/os-release` is installed as the relative selector `../usr/share/omarchy/etc-overrides/os-release`; removal restores only that exact selector to Arch's `../usr/lib/os-release` and preserves custom state.
- Stale `backup=()` entries for files no longer present in the package are removed.
- The zram optional dependency wording now describes the setting it actually supports.

Together with omacom/omarchy#9070, this makes static system state package-backed after the one-time Quattro ownership adoption. Ordinary updates no longer need `--overwrite` or a root-path recovery mechanism.

## Proof

```bash
for package in omarchy-settings omarchy-settings-dev; do
  (cd "pkgbuilds/$package" && makepkg --printsrcinfo >/dev/null)
done

./bin/omarchy-pkgs self-test
./bin/omarchy-release self-test
```

To materialize both development packages against the linked Omarchy checkout:

```bash
export OMARCHY_SRC=/path/to/omarchy
artifact_dir=$(mktemp -d)

for package in omarchy-dev omarchy-settings-dev; do
  (
    cd "pkgbuilds/$package"
    env OMARCHY_SRC="$OMARCHY_SRC" PKGDEST="$artifact_dir" makepkg --nodeps --force --cleanbuild --clean
  )
done
```

The install-script lifecycle was also exercised in an isolated mount namespace, including install, upgrade, exact-selector removal, dangling-selector recovery, and preservation of custom `/etc/os-release` state.

## Release gate

1. Merge omacom/omarchy#9070.
2. Merge this PR.
3. Pick omacom/omarchy#9070 into the v4.0.2 patch train and stage these package changes with it.
4. Test the release candidate, then ship v4.0.2 so `omarchy` and `omarchy-settings` are pinned together.
5. Only after v4.0.2 is published, merge the 3.x bootstrap PRs.

```bash
bin/omarchy-release pick 9070
bin/omarchy-release rc
# After validating the release candidate:
bin/omarchy-release ship
```

The gated legacy launchers are omacom/omarchy#9072 for `master`, omacom/omarchy#9073 for `rc`, and omacom/omarchy#9071 for `dev`.
